### PR TITLE
Redesign Training & Planning surfaces

### DIFF
--- a/src/components/DateStrip.jsx
+++ b/src/components/DateStrip.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { CalendarDays, MapPin } from 'lucide-react';
 
+const WEEKDAY_FORMAT = { weekday: 'short' };
+
 export default function DateStrip({
   currentDate,
   onDateChange,
@@ -68,11 +70,15 @@ export default function DateStrip({
     return parseLocalDate(dateStr).getDate();
   };
 
+  const formatWeekday = (dateStr) => {
+    return parseLocalDate(dateStr).toLocaleDateString('en-US', WEEKDAY_FORMAT);
+  };
+
   const formatMonthYear = (dateStr) => {
     const date = parseLocalDate(dateStr);
     const month = date.toLocaleString('default', { month: 'short' });
     const year = date.getFullYear();
-    return `${month.toUpperCase()} '${String(year).slice(-2)}`;
+    return `${month} ${year}`;
   };
 
   return (
@@ -110,13 +116,21 @@ export default function DateStrip({
               <button
                 key={dateStr}
                 data-date={dateStr}
+                type="button"
                 className={`date-strip__day ${
                   isSelected ? 'date-strip__day--selected' : ''
                 } ${hasWorkout ? 'date-strip__day--scheduled' : ''} ${
                   isCompleted ? 'date-strip__day--completed' : ''
                 } ${isToday ? 'date-strip__day--today' : ''}`}
                 onClick={() => onDateChange(dateStr)}
+                aria-current={isSelected ? 'date' : undefined}
+                aria-label={`${formatWeekday(dateStr)} ${formatDateDisplay(dateStr)}${
+                  hasWorkout ? ', workout scheduled' : ', rest day'
+                }${isCompleted ? ', completed' : ''}`}
               >
+                <div className="date-strip__weekday">
+                  {formatWeekday(dateStr)}
+                </div>
                 <div className="date-strip__day-number">
                   {formatDateDisplay(dateStr)}
                 </div>

--- a/src/components/MonthCalendar.jsx
+++ b/src/components/MonthCalendar.jsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from 'react';
+import { CalendarDays, ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react';
 
 const MONTH_NAMES = [
   'January', 'February', 'March', 'April', 'May', 'June',
@@ -111,27 +112,47 @@ export default function MonthCalendar({
   return (
     <div className="month-calendar">
       <div className="month-calendar__header flex-between">
-        <button className="btn btn-secondary btn-small" onClick={goToPreviousMonth}>
-          ←
+        <button
+          className="month-calendar__nav-btn"
+          onClick={goToPreviousMonth}
+          aria-label="Previous month"
+        >
+          <ChevronLeft size={18} />
         </button>
         <div className="month-calendar__title-wrapper">
           <button
             className="month-calendar__title-btn"
             onClick={() => setShowPicker(!showPicker)}
+            aria-expanded={showPicker}
           >
+            <CalendarDays size={16} aria-hidden="true" />
             <h2 className="month-calendar__title">{getMonthYearDisplay()}</h2>
-            <span className="month-calendar__title-caret">{showPicker ? '▴' : '▾'}</span>
+            <ChevronDown
+              size={16}
+              className={`month-calendar__title-caret ${
+                showPicker ? 'month-calendar__title-caret--open' : ''
+              }`}
+              aria-hidden="true"
+            />
           </button>
 
           {showPicker && (
             <div className="month-picker" ref={pickerRef}>
               <div className="month-picker__year-row">
-                <button className="btn btn-secondary btn-small" onClick={() => jumpToYear(-1)}>
-                  ←
+                <button
+                  className="month-picker__year-btn"
+                  onClick={() => jumpToYear(-1)}
+                  aria-label="Previous year"
+                >
+                  <ChevronLeft size={16} />
                 </button>
                 <span className="month-picker__year">{displayMonth.year}</span>
-                <button className="btn btn-secondary btn-small" onClick={() => jumpToYear(1)}>
-                  →
+                <button
+                  className="month-picker__year-btn"
+                  onClick={() => jumpToYear(1)}
+                  aria-label="Next year"
+                >
+                  <ChevronRight size={16} />
                 </button>
               </div>
               <div className="month-picker__months">
@@ -150,10 +171,14 @@ export default function MonthCalendar({
             </div>
           )}
         </div>
-        <button className="btn btn-secondary btn-small" onClick={goToNextMonth}>
-          →
+        <button
+          className="month-calendar__nav-btn"
+          onClick={goToNextMonth}
+          aria-label="Next month"
+        >
+          <ChevronRight size={18} />
         </button>
-        <button className="btn btn-secondary btn-small" onClick={goToToday}>
+        <button className="month-calendar__today-btn" onClick={goToToday}>
           Today
         </button>
       </div>
@@ -197,11 +222,17 @@ export default function MonthCalendar({
               } ${isToday ? 'month-calendar__day--today' : ''}`}
               onClick={() => onDateChange(dateStr)}
               title={schedule[dateStr] || 'No workout'}
+              aria-current={isSelected ? 'date' : undefined}
             >
               <div className="month-calendar__day-number">{day}</div>
               {hasWorkout && (
                 <div className="month-calendar__day-label">
-                  {isCompleted ? '✓' : isPast ? '✗' : '•'}
+                  <span className="month-calendar__status-mark" aria-hidden="true">
+                    {isCompleted ? '✓' : isPast ? '!' : '•'}
+                  </span>
+                  <span className="month-calendar__status-text">
+                    {isCompleted ? 'Done' : isPast ? 'Missed' : 'Planned'}
+                  </span>
                 </div>
               )}
               {schedule[dateStr] && (

--- a/src/components/TemplatePreviewSheet.jsx
+++ b/src/components/TemplatePreviewSheet.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { X, Play, CalendarPlus } from 'lucide-react';
 
 export default function TemplatePreviewSheet({
@@ -6,42 +7,80 @@ export default function TemplatePreviewSheet({
   onSchedule,
   onClose,
 }) {
+  useEffect(() => {
+    const handler = (event) => {
+      if (event.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [onClose]);
+
   if (!template) return null;
 
   const exerciseCount = template.blocks.reduce(
     (sum, b) => sum + b.exercises.length,
     0
   );
+  const setCount = template.blocks.reduce(
+    (sum, block) => sum + block.exercises.reduce(
+      (exerciseSum, exercise) => exerciseSum + exercise.sets.length,
+      0
+    ),
+    0
+  );
 
   return (
     <div className="tpl-preview-overlay" onClick={onClose}>
-      <div className="tpl-preview-sheet" onClick={(e) => e.stopPropagation()}>
+      <div
+        className="tpl-preview-sheet"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="tpl-preview-title"
+      >
+        <div className="tpl-preview__grabber" aria-hidden="true" />
         <div className="tpl-preview__header">
-          <h2 className="tpl-preview__title">{template.name}</h2>
-          <button className="tpl-preview__close" onClick={onClose}>
+          <div>
+            <span className="tpl-preview__kicker">Template preview</span>
+            <h2 id="tpl-preview-title" className="tpl-preview__title">{template.name}</h2>
+          </div>
+          <button className="tpl-preview__close" onClick={onClose} aria-label="Close template preview">
             <X size={20} />
           </button>
         </div>
-        <p className="tpl-preview__meta">
-          {exerciseCount} exercise{exerciseCount !== 1 ? 's' : ''}
-        </p>
+
+        <div className="tpl-preview__meta" aria-label="Template summary">
+          <span>{exerciseCount} exercise{exerciseCount !== 1 ? 's' : ''}</span>
+          <span>{setCount} set{setCount !== 1 ? 's' : ''}</span>
+          <span>{template.blocks.length} part{template.blocks.length !== 1 ? 's' : ''}</span>
+        </div>
 
         <div className="tpl-preview__exercises">
           {template.blocks.map((block, bIdx) => {
             const isSuperset = block.exercises.length > 1;
             return (
-              <div key={bIdx}>
-                {isSuperset && (
-                  <div className="tpl-preview__superset-label">Superset</div>
-                )}
-                {block.exercises.map((ex, eIdx) => (
-                  <div key={eIdx} className="tpl-preview__exercise-row">
-                    <span className="tpl-preview__exercise-name">{ex.title}</span>
-                    <span className="tpl-preview__exercise-sets">
-                      {ex.sets.length} set{ex.sets.length !== 1 ? 's' : ''}
-                    </span>
-                  </div>
-                ))}
+              <div
+                key={bIdx}
+                className={`tpl-preview__block ${isSuperset ? 'tpl-preview__block--superset' : ''}`}
+              >
+                <div className="tpl-preview__block-heading">
+                  <span className="tpl-preview__block-letter">
+                    {block.value || String.fromCharCode(65 + bIdx)}
+                  </span>
+                  {isSuperset && (
+                    <span className="tpl-preview__superset-label">Superset</span>
+                  )}
+                </div>
+                <div className="tpl-preview__block-list">
+                  {block.exercises.map((ex, eIdx) => (
+                    <div key={eIdx} className="tpl-preview__exercise-row">
+                      <span className="tpl-preview__exercise-name">{ex.title}</span>
+                      <span className="tpl-preview__exercise-sets">
+                        {ex.sets.length} set{ex.sets.length !== 1 ? 's' : ''}
+                      </span>
+                    </div>
+                  ))}
+                </div>
               </div>
             );
           })}

--- a/src/components/TemplatePreviewSheet.jsx
+++ b/src/components/TemplatePreviewSheet.jsx
@@ -6,6 +6,7 @@ export default function TemplatePreviewSheet({
   onStartNow,
   onSchedule,
   onClose,
+  startDisabledReason = '',
 }) {
   useEffect(() => {
     const handler = (event) => {
@@ -87,10 +88,17 @@ export default function TemplatePreviewSheet({
         </div>
 
         <div className="tpl-preview__actions">
-          <button className="tpl-preview__start-btn" onClick={onStartNow}>
+          <button
+            className="tpl-preview__start-btn"
+            onClick={onStartNow}
+            disabled={!!startDisabledReason}
+          >
             <Play size={18} />
             Start Now
           </button>
+          {startDisabledReason && (
+            <p className="tpl-preview__start-note">{startDisabledReason}</p>
+          )}
           <button className="tpl-preview__schedule-btn" onClick={onSchedule}>
             <CalendarPlus size={18} />
             Schedule

--- a/src/components/WorkoutPreviewCard.jsx
+++ b/src/components/WorkoutPreviewCard.jsx
@@ -1,8 +1,27 @@
 import { useState } from 'react';
-import { Save, Check, MessageSquare } from 'lucide-react';
+import { Check, Dumbbell, MessageSquare, Play, Save } from 'lucide-react';
+
+function getExerciseCount(workout) {
+  return (workout.blocks || []).reduce(
+    (total, block) => total + (block.exercises?.length || 0),
+    0
+  );
+}
+
+function getSetCount(workout) {
+  return (workout.blocks || []).reduce(
+    (total, block) => total + (block.exercises || []).reduce(
+      (blockTotal, exercise) => blockTotal + (exercise.sets?.length || 0),
+      0
+    ),
+    0
+  );
+}
 
 export default function WorkoutPreviewCard({ workout, onStartWorkout, onSaveAsTemplate }) {
   const [saved, setSaved] = useState(false);
+  const exerciseCount = getExerciseCount(workout);
+  const setCount = getSetCount(workout);
 
   const handleSaveTemplate = () => {
     if (onSaveAsTemplate) {
@@ -15,46 +34,90 @@ export default function WorkoutPreviewCard({ workout, onStartWorkout, onSaveAsTe
   };
 
   return (
-    <div className="workout-preview-card card">
-      <div className="flex-between mb-md">
-        <div className="workout-preview-card__coach">
-          <div className="workout-preview-card__coach-avatar">
-            {workout.title
-              .split(' ')
-              .slice(0, 2)
-              .map((w) => w[0])
-              .join('')
-              .toUpperCase()}
-          </div>
+    <section className="workout-preview-card card" aria-labelledby="today-workout-title">
+      <div className="workout-preview-card__topline">
+        <div className="workout-preview-card__badge">
+          <Dumbbell size={16} aria-hidden="true" />
+          Today&apos;s session
         </div>
         {onSaveAsTemplate && (
           <button
-            className="btn btn-secondary btn-small"
+            className="workout-preview-card__save"
             onClick={handleSaveTemplate}
             disabled={saved}
           >
             {saved
-              ? <><Check size={13} style={{ marginRight: '4px', verticalAlign: 'middle' }} />Saved</>
-              : <><Save size={13} style={{ marginRight: '4px', verticalAlign: 'middle' }} />Save Template</>}
+              ? <><Check size={14} />Saved</>
+              : <><Save size={14} />Save</>}
           </button>
         )}
       </div>
 
-      <h2 className="workout-preview-card__title">{workout.title}</h2>
+      <h2 id="today-workout-title" className="workout-preview-card__title">
+        {workout.title}
+      </h2>
+
+      <div className="workout-preview-card__metrics" aria-label="Workout summary">
+        <div className="workout-preview-card__metric">
+          <span className="workout-preview-card__metric-value">{exerciseCount}</span>
+          <span className="workout-preview-card__metric-label">Exercises</span>
+        </div>
+        <div className="workout-preview-card__metric">
+          <span className="workout-preview-card__metric-value">{setCount}</span>
+          <span className="workout-preview-card__metric-label">Sets</span>
+        </div>
+        <div className="workout-preview-card__metric">
+          <span className="workout-preview-card__metric-value">{workout.blocks?.length || 0}</span>
+          <span className="workout-preview-card__metric-label">Parts</span>
+        </div>
+      </div>
 
       <button
-        className="btn btn-primary btn--large w-full mt-lg"
+        className="workout-preview-card__start"
         onClick={onStartWorkout}
       >
-        Start Session
+        <Play size={18} fill="currentColor" aria-hidden="true" />
+        Start Workout
       </button>
 
       {workout.notes && (
-        <div className="mt-lg">
-          <div className="text-blue mt-md mb-md" style={{ display: 'flex', alignItems: 'center', gap: '5px' }}><MessageSquare size={14} /> Workout Notes</div>
-          <p className="text-secondary">{workout.notes}</p>
+        <div className="workout-preview-card__notes">
+          <div className="workout-preview-card__notes-label">
+            <MessageSquare size={14} aria-hidden="true" />
+            Workout notes
+          </div>
+          <p>{workout.notes}</p>
         </div>
       )}
-    </div>
+
+      <div className="workout-preview-card__exercises">
+        {(workout.blocks || []).map((block, blockIdx) => {
+          const isSuperset = (block.exercises || []).length > 1;
+          return (
+            <div
+              key={blockIdx}
+              className={`workout-preview-card__block ${
+                isSuperset ? 'workout-preview-card__block--superset' : ''
+              }`}
+            >
+              <div className="workout-preview-card__block-label">
+                <span>{block.value || String.fromCharCode(65 + blockIdx)}</span>
+                {isSuperset && <strong>Superset</strong>}
+              </div>
+              <div className="workout-preview-card__block-exercises">
+                {(block.exercises || []).map((exercise, exIdx) => (
+                  <div key={exIdx} className="workout-preview-card__exercise-row">
+                    <span className="workout-preview-card__exercise-name">{exercise.title}</span>
+                    <span className="workout-preview-card__exercise-sets">
+                      {exercise.sets?.length || 0} set{(exercise.sets?.length || 0) !== 1 ? 's' : ''}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
   );
 }

--- a/src/styles/calendar.css
+++ b/src/styles/calendar.css
@@ -1,482 +1,322 @@
-/* ========== DateStrip ========== */
-.date-strip {
-  background-color: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-  padding: var(--space-md) var(--space-lg);
-}
-
-.date-strip__header {
-  margin-bottom: var(--space-md);
-}
-
-.date-strip__month-year {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
-}
-
-.date-strip__controls {
-  display: flex;
-  gap: var(--space-sm);
-}
-
-.date-strip__scroll {
-  overflow-x: auto;
-  overflow-y: hidden;
-  -webkit-overflow-scrolling: touch;
-  scroll-behavior: smooth;
-}
-
-.date-strip__days {
-  display: flex;
-  min-width: 100%;
-  justify-content: space-evenly;
-  padding-bottom: var(--space-sm);
-}
-
-.date-strip__day {
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: var(--space-md) var(--space-sm);
-  border: none;
-  background: none;
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  transition: all var(--transition);
-  border-radius: var(--radius-lg);
-  min-width: 52px;
-  min-height: 56px;
-  position: relative;
-}
-
-.date-strip__day-number {
-  font-size: var(--font-size-base);
-  font-weight: 500;
-}
-
-.date-strip__day-indicator {
-  font-size: 10px;
-  line-height: 1;
-}
-
-.date-strip__day--scheduled .date-strip__day-indicator {
-  color: var(--color-accent-blue);
-}
-
-.date-strip__day--completed {
-  color: var(--color-accent-green);
-}
-
-.date-strip__day--completed .date-strip__day-indicator {
-  color: var(--color-accent-green);
-}
-
-.date-strip__day--today {
-  position: relative;
-}
-
-.date-strip__day--today::after {
-  content: '';
-  position: absolute;
-  bottom: 4px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background-color: var(--color-accent-blue);
-}
-
-.date-strip__day--selected {
-  color: white;
-  background-color: var(--color-accent-blue);
-  box-shadow: 0 0 16px rgba(99, 102, 241, 0.3);
-}
-
-.date-strip__day--selected.date-strip__day--today::after {
-  background-color: white;
-}
-
 /* ========== MonthCalendar ========== */
 .month-calendar {
-  background-color: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
   padding: var(--space-lg);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--surface);
 }
 
 .month-calendar__header {
-  display: flex;
-  justify-content: space-between;
+  position: relative;
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr) 40px auto;
   align-items: center;
+  gap: var(--space-sm);
   margin-bottom: var(--space-lg);
-  gap: var(--space-md);
 }
 
-.month-calendar__title {
-  font-size: var(--font-size-xl);
-  font-weight: 600;
-  text-align: center;
-  flex: 1;
+.month-calendar__nav-btn,
+.month-calendar__today-btn,
+.month-picker__year-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 40px;
+  min-height: 40px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-high);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 700;
+}
+
+.month-calendar__today-btn {
+  min-width: 64px;
+  padding-inline: var(--space-md);
+}
+
+.month-calendar__nav-btn:hover,
+.month-calendar__today-btn:hover,
+.month-picker__year-btn:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.month-calendar__nav-btn:active,
+.month-calendar__today-btn:active,
+.month-picker__year-btn:active {
+  transform: scale(0.97);
 }
 
 .month-calendar__title-wrapper {
   position: relative;
-  flex: 1;
   display: flex;
+  min-width: 0;
   justify-content: center;
 }
 
 .month-calendar__title-btn {
-  display: flex;
+  display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-sm);
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: inherit;
-  padding: var(--space-xs) var(--space-sm);
-  border-radius: 8px;
-  transition: background-color var(--transition);
+  max-width: 100%;
+  min-height: 40px;
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--text);
 }
 
 .month-calendar__title-btn:hover {
-  background-color: rgba(75, 123, 255, 0.1);
+  border-color: var(--border);
+  background: var(--surface-high);
+}
+
+.month-calendar__title {
+  overflow: hidden;
+  margin: 0;
+  color: var(--text);
+  font-size: var(--text-xl);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .month-calendar__title-caret {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
+  flex-shrink: 0;
+  color: var(--text-muted);
+  transition: transform var(--transition);
+}
+
+.month-calendar__title-caret--open {
+  transform: rotate(180deg);
 }
 
 /* ========== Month/Year Picker ========== */
 .month-picker {
   position: absolute;
-  top: 100%;
+  z-index: var(--z-dropdown);
+  top: calc(100% + var(--space-sm));
   left: 50%;
-  transform: translateX(-50%);
-  z-index: 60;
-  background-color: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 12px;
+  width: min(304px, calc(100vw - 2 * var(--space-lg)));
   padding: var(--space-lg);
-  box-shadow: var(--shadow-md);
-  min-width: 260px;
-  margin-top: var(--space-sm);
+  transform: translateX(-50%);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--surface-elevated);
+  box-shadow: var(--shadow-lg);
 }
 
 .month-picker__year-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--space-md);
   margin-bottom: var(--space-md);
 }
 
 .month-picker__year {
-  font-size: var(--font-size-lg);
-  font-weight: 600;
+  color: var(--text);
+  font-size: var(--text-lg);
+  font-weight: 800;
+  font-feature-settings: 'tnum' 1;
 }
 
 .month-picker__months {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: var(--space-sm);
 }
 
 .month-picker__month {
+  min-height: 42px;
   padding: var(--space-sm) var(--space-md);
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
-  background: none;
-  color: var(--color-text-primary);
-  cursor: pointer;
-  font-size: var(--font-size-sm);
-  font-weight: 500;
-  text-align: center;
-  transition: all var(--transition);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-high);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 750;
 }
 
 .month-picker__month:hover {
-  background-color: rgba(75, 123, 255, 0.1);
-  border-color: var(--color-accent-blue);
+  border-color: var(--border-strong);
+  color: var(--text);
 }
 
 .month-picker__month--active {
-  background-color: var(--color-accent-blue);
-  border-color: var(--color-accent-blue);
-  color: white;
+  border-color: var(--accent-line);
+  background: var(--accent-subtle);
+  color: var(--accent-text);
 }
 
-.month-calendar__controls {
-  display: flex;
-  justify-content: center;
-  margin-bottom: var(--space-md);
-}
-
+/* ========== Calendar grid ========== */
 .month-calendar__grid {
   display: grid;
-  grid-template-columns: repeat(7, 1fr);
-  gap: var(--space-sm);
-  margin-bottom: var(--space-md);
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: var(--space-xs);
 }
 
 .month-calendar__weekday {
+  padding: var(--space-xs) 0 var(--space-sm);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 750;
+  letter-spacing: 0.04em;
   text-align: center;
-  font-weight: 600;
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-sm);
-  padding: var(--space-md) var(--space-sm);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
 }
 
 .month-calendar__day {
-  aspect-ratio: 1;
+  position: relative;
   display: flex;
+  min-width: 0;
+  min-height: 68px;
+  aspect-ratio: 0.82;
   flex-direction: column;
   align-items: center;
   justify-content: flex-start;
-  padding: var(--space-sm);
-  border: 1px solid var(--color-border);
-  border-radius: 8px;
-  background-color: var(--color-bg);
-  color: var(--color-text-primary);
-  cursor: pointer;
-  transition: all var(--transition);
-  font-weight: 500;
-  position: relative;
-  min-height: 80px;
+  gap: var(--space-1);
+  padding: var(--space-sm) var(--space-xs);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--surface-high) 44%, transparent);
+  color: var(--text-secondary);
+}
+
+.month-calendar__day:hover:not(.month-calendar__day--empty) {
+  border-color: var(--border-strong);
+  background: var(--surface-high);
+}
+
+.month-calendar__day:active:not(.month-calendar__day--empty) {
+  transform: scale(0.98);
 }
 
 .month-calendar__day--empty {
-  background-color: transparent;
-  border: none;
-  cursor: default;
+  border-color: transparent;
+  background: transparent;
   pointer-events: none;
 }
 
 .month-calendar__day-number {
-  font-size: var(--font-size-lg);
-  font-weight: 600;
-  margin-bottom: var(--space-xs);
+  color: var(--text);
+  font-size: var(--text-md);
+  font-weight: 800;
+  font-feature-settings: 'tnum' 1;
+  line-height: 1;
 }
 
 .month-calendar__day-label {
-  font-size: var(--font-size-sm);
-  margin-bottom: var(--space-xs);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  min-height: 18px;
+  margin-top: var(--space-1);
+  border-radius: var(--radius-full);
+  font-size: 0.6875rem;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.month-calendar__status-mark {
+  line-height: 1;
+}
+
+.month-calendar__status-text {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
 }
 
 .month-calendar__day-workout {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
-  text-align: center;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  display: -webkit-box;
   width: 100%;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: 0.6875rem;
+  font-weight: 650;
+  line-height: 1.15;
+  text-align: center;
+  overflow-wrap: anywhere;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
-/* Day status colors */
 .month-calendar__day--scheduled {
-  border-color: var(--color-accent-blue);
-  background-color: rgba(75, 123, 255, 0.05);
+  border-color: var(--accent-line);
+  background: var(--accent-subtle);
 }
 
-.month-calendar__day--scheduled:hover {
-  background-color: rgba(75, 123, 255, 0.1);
-  border-color: var(--color-accent-blue);
+.month-calendar__day--scheduled .month-calendar__day-label {
+  background: color-mix(in oklch, var(--accent) 18%, transparent);
+  color: var(--accent-text);
 }
 
 .month-calendar__day--completed {
-  border-color: var(--color-accent-green);
-  background-color: rgba(48, 209, 88, 0.05);
+  border-color: color-mix(in oklch, var(--success) 38%, var(--border));
+  background: var(--success-subtle);
 }
 
-.month-calendar__day--completed:hover {
-  background-color: rgba(48, 209, 88, 0.1);
+.month-calendar__day--completed .month-calendar__day-label {
+  background: color-mix(in oklch, var(--success) 18%, transparent);
+  color: var(--success);
 }
 
 .month-calendar__day--missed {
-  border-color: var(--color-accent-red);
-  background-color: rgba(255, 59, 48, 0.05);
+  border-color: color-mix(in oklch, var(--danger) 36%, var(--border));
+  background: var(--danger-subtle);
 }
 
-.month-calendar__day--missed:hover {
-  background-color: rgba(255, 59, 48, 0.1);
+.month-calendar__day--missed .month-calendar__day-label {
+  background: color-mix(in oklch, var(--danger) 18%, transparent);
+  color: var(--danger);
 }
 
 .month-calendar__day--selected {
-  border-color: var(--color-accent-blue);
-  border-width: 2px;
-  background-color: rgba(75, 123, 255, 0.15);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-subtle);
 }
 
-.month-calendar__day--today {
-  border-color: var(--color-accent-yellow);
-  border-width: 2px;
+.month-calendar__day--today::after {
+  content: '';
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: var(--accent);
 }
 
-.month-calendar__day:hover:not(.month-calendar__day--empty) {
-  background-color: var(--color-surface);
-  border-color: var(--color-accent-blue);
-}
-
-/* ========== TrainingView Month Header ========== */
-.training-view__month-header {
-  display: flex;
-  flex-direction: column;
-}
-
-.training-view__month-controls {
-  display: flex;
-  justify-content: center;
-  padding-top: var(--space-md);
-  border-top: 1px solid var(--color-border);
-}
-
-.btn--active {
-  background-color: var(--color-accent-blue);
-  color: white;
-}
-
-.btn--active:active {
-  opacity: 0.8;
-}
-
-/* Mobile responsiveness */
-@media (max-width: 768px) {
+@media (max-width: 420px) {
   .month-calendar {
     padding: var(--space-md);
   }
 
-  .month-calendar__grid {
-    gap: var(--space-xs);
+  .month-calendar__header {
+    grid-template-columns: 38px minmax(0, 1fr) 38px;
+  }
+
+  .month-calendar__today-btn {
+    grid-column: 1 / -1;
+    width: fit-content;
+    justify-self: center;
   }
 
   .month-calendar__day {
-    min-height: 70px;
-    padding: var(--space-xs);
-    font-size: var(--font-size-sm);
-  }
-
-  .month-calendar__day-number {
-    font-size: var(--font-size-base);
+    min-height: 58px;
+    padding: var(--space-sm) var(--space-1);
   }
 
   .month-calendar__day-workout {
-    font-size: var(--font-size-xs);
-  }
-
-  .month-calendar__header {
-    gap: var(--space-sm);
-  }
-
-  .date-strip__header {
-    flex-direction: column;
-    gap: var(--space-md);
-  }
-}
-
-/* ========== DateStrip (consolidated from components.css) ========== */
-.date-strip {
-  background-color: var(--color-surface);
-  border-bottom: 1px solid var(--color-border);
-  padding: var(--space-md) var(--space-lg);
-}
-
-.date-strip__header {
-  margin-bottom: var(--space-md);
-}
-
-.date-strip__month-year {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
-}
-
-.date-strip__scroll {
-  overflow-x: auto;
-  overflow-y: hidden;
-  -webkit-overflow-scrolling: touch;
-  scroll-behavior: smooth;
-}
-
-.date-strip__days {
-  display: flex;
-  gap: var(--space-md);
-  padding-bottom: var(--space-sm);
-}
-
-.date-strip__day {
-  flex-shrink: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-xs);
-  padding: var(--space-md) var(--space-sm);
-  border: none;
-  background: none;
-  cursor: pointer;
-  color: var(--color-text-secondary);
-  transition: all var(--transition);
-  border-radius: var(--radius-lg);
-  min-width: 52px;
-  min-height: 56px;
-  position: relative;
-}
-
-.date-strip__day-number {
-  font-size: var(--font-size-base);
-  font-weight: 500;
-}
-
-.date-strip__day-indicator {
-  font-size: 10px;
-  line-height: 1;
-}
-
-.date-strip__day--scheduled .date-strip__day-indicator {
-  color: var(--color-accent-blue);
-}
-
-.date-strip__day--completed {
-  color: var(--color-accent-green);
-}
-
-.date-strip__day--completed .date-strip__day-indicator {
-  color: var(--color-accent-green);
-}
-
-.date-strip__day--today {
-  position: relative;
-}
-
-.date-strip__day--today::after {
-  content: '';
-  position: absolute;
-  bottom: 4px;
-  left: 50%;
-  transform: translateX(-50%);
-  width: 5px;
-  height: 5px;
-  border-radius: 50%;
-  background-color: var(--color-accent-blue);
-}
-
-.date-strip__day--selected {
-  color: white;
-  background-color: var(--color-accent-blue);
-  box-shadow: 0 0 16px rgba(99, 102, 241, 0.3);
-}
-
-.date-strip__day--selected.date-strip__day--today::after {
-  background-color: white;
-}
-
-@media (max-width: 768px) {
-  .date-strip__day {
-    min-height: 56px;
-    padding: var(--space-md) var(--space-md);
-    gap: var(--space-sm);
+    display: none;
   }
 }

--- a/src/styles/planner.css
+++ b/src/styles/planner.css
@@ -1,191 +1,362 @@
 /* ========== WeekPlannerView ========== */
+.planner-view {
+  background: var(--bg);
+}
+
 .planner-view__header {
-  padding: var(--space-lg);
-  padding-bottom: var(--space-md);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  padding: var(--space-xl) var(--space-lg) var(--space-md);
 }
 
 .planner-view__header h1 {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-bold);
-  margin-bottom: var(--space-xs);
+  margin: 0;
+  color: var(--text);
+  font-size: var(--text-2xl);
+  font-weight: 800;
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+}
+
+.planner-view__range {
+  margin: var(--space-xs) 0 0;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.planner-view__status-row {
+  display: flex;
+  align-items: center;
+  min-height: 32px;
 }
 
 .planner-draft-badge {
-  font-size: var(--font-size-xs);
-  color: var(--color-accent-yellow);
-  font-weight: var(--font-weight-semibold);
-  letter-spacing: 0.02em;
-  background: rgba(251, 191, 36, 0.12);
-  padding: 2px var(--space-sm);
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: var(--space-xs) var(--space-md);
+  border: 1px solid color-mix(in oklch, var(--warning) 30%, transparent);
   border-radius: var(--radius-full);
+  background: var(--warning-subtle);
+  color: var(--warning);
+  font-size: var(--text-xs);
+  font-weight: 800;
 }
 
 .planner-view__nav {
-  display: flex;
-  justify-content: center;
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr) 44px;
   gap: var(--space-sm);
-  padding: 0 var(--space-lg) var(--space-md);
+  padding: 0 var(--space-lg) var(--space-lg);
+}
+
+.planner-view__nav .btn {
+  width: 100%;
 }
 
 .planner-view__grid {
   display: flex;
   flex-direction: column;
-  gap: 0;
+  gap: var(--space-sm);
   padding: 0 var(--space-lg);
 }
 
-.planner-day {
-  display: flex;
-  align-items: center;
-  gap: var(--space-md);
-  padding: var(--space-lg);
-  border-bottom: 1px solid var(--color-border-subtle);
-  min-height: 52px;
-  transition: background-color var(--transition);
+.planner-day.card {
+  margin: 0;
 }
 
-.planner-day:last-child {
-  border-bottom: none;
+.planner-day {
+  display: grid;
+  grid-template-columns: 48px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-md);
+  min-height: 86px;
+  padding: var(--space-md);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xl);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+  transition: background-color var(--transition), border-color var(--transition), transform var(--dur-fast) var(--ease-out-quart);
+}
+
+.planner-day:hover {
+  border-color: var(--border);
 }
 
 .planner-day--today {
-  border-left: 3px solid var(--color-accent-blue);
-  background: var(--color-accent-subtle);
+  border-color: var(--accent-line);
+  background: var(--accent-subtle);
 }
 
 .planner-day--draft {
-  border-left: 3px solid var(--color-accent-yellow);
+  border-color: color-mix(in oklch, var(--warning) 36%, var(--border));
+  background: color-mix(in oklch, var(--warning-subtle) 72%, var(--surface));
 }
 
 .planner-day__header {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: 10px minmax(0, 1fr);
+  grid-template-rows: auto auto;
+  column-gap: var(--space-sm);
   align-items: center;
-  min-width: 40px;
+  min-width: 0;
+}
+
+.planner-day__marker {
+  grid-row: 1 / 3;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background: var(--border-strong);
+}
+
+.planner-day--today .planner-day__marker {
+  background: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-subtle);
+}
+
+.planner-day--draft .planner-day__marker {
+  background: var(--warning);
+  box-shadow: 0 0 0 4px var(--warning-subtle);
 }
 
 .planner-day__name {
-  font-size: var(--font-size-xs);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 800;
+  letter-spacing: 0.04em;
 }
 
 .planner-day__date {
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
+  color: var(--text);
+  font-size: var(--text-xl);
+  font-weight: 800;
+  font-feature-settings: 'tnum' 1;
+  line-height: 1;
 }
 
 .planner-day__workout {
-  flex: 1;
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-sm);
+  min-width: 0;
 }
 
 .planner-day__workout-name {
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: pointer;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  background: transparent;
+  color: var(--text);
+  font-size: var(--text-md);
+  font-weight: 750;
+  line-height: 1.25;
   text-align: left;
-  font-weight: var(--font-weight-medium);
-  font-size: var(--font-size-base);
-  color: var(--color-accent-blue);
-  text-decoration: none;
-  transition: color var(--transition);
 }
 
-.planner-day__workout-name:hover {
-  color: var(--color-accent-hover);
+.planner-day__workout-name:hover:not(:disabled) {
+  color: var(--accent-text);
+}
+
+.planner-day__workout-name:disabled {
+  cursor: default;
+  color: var(--text-secondary);
 }
 
 .planner-day__clear {
-  background: none;
-  border: none;
-  color: var(--color-text-muted);
-  cursor: pointer;
-  font-size: var(--font-size-sm);
-  padding: var(--space-sm);
-  min-width: 44px;
-  min-height: 44px;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--radius-sm);
-  transition: color var(--transition);
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--text-muted);
 }
 
 .planner-day__clear:hover {
-  color: var(--color-accent-red);
+  border-color: var(--danger-subtle);
+  background: var(--danger-subtle);
+  color: var(--danger);
+}
+
+.planner-day__clear:active {
+  transform: scale(0.94);
 }
 
 .planner-day__empty {
-  flex: 1;
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-  font-style: italic;
+  min-width: 0;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-weight: 650;
 }
 
 .planner-day__assign {
   flex-shrink: 0;
+  min-width: 88px;
 }
 
 .planner-view__actions {
-  padding: var(--space-lg);
-  padding-bottom: var(--space-xl);
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
+  padding: var(--space-lg);
+  padding-bottom: calc(var(--space-2xl) + env(safe-area-inset-bottom, 0px));
 }
 
 .planner-view__actions .btn-primary {
   width: 100%;
-  min-height: 52px;
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
+  min-height: 54px;
   border-radius: var(--radius-lg);
 }
 
 .planner-view__secondary-actions {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-sm);
+}
+
+.planner-view__secondary-actions .btn {
+  width: 100%;
+}
+
+.planner-empty-state {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  margin: 0 var(--space-lg) var(--space-md);
+  padding: var(--space-lg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--surface);
+  color: var(--text-secondary);
+}
+
+.planner-empty-state__icon {
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-full);
+  background: var(--accent-subtle);
+  color: var(--accent-text);
+}
+
+.planner-empty-state p {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: 650;
+  line-height: 1.4;
 }
 
 /* ========== Template Picker Modal ========== */
+.planner-view .modal-overlay {
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
 .template-picker {
-  max-height: 70vh;
-  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  max-height: min(76vh, 620px);
+}
+
+.template-picker__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-lg);
+}
+
+.template-picker .modal__title {
+  margin-bottom: var(--space-xs);
+}
+
+.template-picker .modal__message {
+  margin: 0;
+}
+
+.template-picker__close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: var(--surface-high);
+  color: var(--text-secondary);
+}
+
+.template-picker__close:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.template-picker__search {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-height: 48px;
+  padding: 0 var(--space-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--surface-high);
+  color: var(--text-muted);
+}
+
+.template-picker__search:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
+}
+
+.template-picker__search input {
+  min-height: 46px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.template-picker__search input:focus {
+  box-shadow: none;
 }
 
 .template-picker__list {
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
+  overflow-y: auto;
 }
 
 .template-picker__item {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--space-md);
   width: 100%;
-  padding: var(--space-lg);
-  background-color: var(--color-bg);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-md);
-  cursor: pointer;
-  color: var(--color-text-primary);
-  transition: all var(--transition);
+  min-height: 58px;
+  padding: var(--space-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--surface-high);
+  color: var(--text);
   text-align: left;
-  min-height: 48px;
 }
 
 .template-picker__item:hover {
-  border-color: var(--color-accent-blue);
-  background-color: var(--color-accent-subtle);
+  border-color: var(--accent-line);
+  background: var(--accent-subtle);
 }
 
 .template-picker__item:active {
@@ -193,43 +364,41 @@
 }
 
 .template-picker__name {
-  font-weight: var(--font-weight-medium);
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-size: var(--text-md);
+  font-weight: 750;
 }
 
-/* ========== Mobile Responsiveness ========== */
-@media (max-width: 768px) {
+.template-picker__meta {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-feature-settings: 'tnum' 1;
+}
+
+@media (max-width: 420px) {
   .planner-view__header {
-    padding: var(--space-md);
-    padding-bottom: var(--space-sm);
+    padding: var(--space-lg) var(--space-md) var(--space-md);
   }
 
-  .planner-view__nav {
-    padding: 0 var(--space-md) var(--space-sm);
-  }
-
-  .planner-view__grid {
-    padding: 0 var(--space-md);
+  .planner-view__nav,
+  .planner-view__grid,
+  .planner-view__actions {
+    padding-inline: var(--space-md);
   }
 
   .planner-day {
-    padding: var(--space-md) var(--space-lg);
-    min-height: 56px;
+    grid-template-columns: 44px minmax(0, 1fr);
   }
 
-  /* Planner clear button: bigger tap target */
-  .planner-day__clear {
-    min-height: 44px;
-    min-width: 44px;
+  .planner-day__assign {
+    grid-column: 2;
+    width: fit-content;
+    min-width: 92px;
   }
 
-  /* Icon buttons: 44×44px tap target */
-  .btn-icon {
-    min-width: 44px;
-    min-height: 44px;
-  }
-
-  .planner-view__actions {
-    padding: var(--space-md);
-    padding-bottom: var(--space-xl);
+  .planner-view__secondary-actions {
+    grid-template-columns: 1fr;
   }
 }

--- a/src/styles/training.css
+++ b/src/styles/training.css
@@ -1,318 +1,739 @@
-/* ========== TrainingView — Home Screen ========== */
+/* ========== Training home ========== */
+.training-view {
+  background: var(--bg);
+}
 
-/* Greeting header */
 .training-greeting {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   justify-content: space-between;
-  padding: var(--space-lg) var(--space-lg) var(--space-sm);
+  gap: var(--space-lg);
+  padding: var(--space-xl) var(--space-lg) var(--space-md);
+}
+
+.training-greeting__copy {
+  min-width: 0;
 }
 
 .training-greeting__text {
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-bold);
   margin: 0;
+  color: var(--text);
+  font-size: var(--text-2xl);
+  font-weight: 800;
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  text-wrap: balance;
+}
+
+.training-greeting__subtext {
+  margin: var(--space-xs) 0 0;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-weight: 500;
 }
 
 .training-greeting__streak {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 4px;
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-accent-yellow);
-  background: rgba(251, 191, 36, 0.12);
+  gap: var(--space-xs);
+  flex-shrink: 0;
+  min-height: 36px;
   padding: var(--space-xs) var(--space-md);
+  border: 1px solid color-mix(in oklch, var(--warning) 28%, transparent);
   border-radius: var(--radius-full);
+  background: var(--warning-subtle);
+  color: var(--warning);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  box-shadow: var(--shadow-sm);
+}
+
+.training-greeting__streak-count {
+  font-family: var(--font-mono);
+  font-feature-settings: 'tnum' 1, 'zero' 1;
 }
 
 .training-view__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
   padding: var(--space-lg);
-  padding-bottom: var(--space-xl);
+  padding-bottom: calc(var(--space-2xl) + env(safe-area-inset-bottom, 0px));
 }
 
-.training-view__exercises {
-  margin-top: var(--space-lg);
+.training-view__month-header {
+  display: flex;
+  flex-direction: column;
 }
 
-/* ========== Workout Card ========== */
-.training-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-xl);
-  padding: 0;
-  box-shadow: var(--shadow-card);
-  overflow: hidden;
+.training-view__month-controls {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-md) var(--space-lg) var(--space-lg);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--surface);
 }
 
-.training-card--completed {
-  border-color: rgba(52, 211, 153, 0.3);
+.btn--active {
+  border-color: var(--accent-line);
+  background: var(--accent-subtle);
+  color: var(--accent-text);
 }
 
-.training-card__header {
+/* ========== DateStrip ========== */
+.date-strip {
+  padding: var(--space-md) var(--space-lg) var(--space-lg);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.date-strip__header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--space-md);
-  padding: var(--space-lg) var(--space-xl);
-  background: linear-gradient(135deg, var(--color-accent-blue), var(--color-accent-hover));
+  margin-bottom: var(--space-md);
 }
 
-.training-card__title {
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-bold);
-  color: white;
+.date-strip__month-year {
   margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-lg);
+  font-weight: 700;
+  letter-spacing: -0.02em;
 }
 
-.training-card__exercise-count {
-  font-size: var(--font-size-sm);
-  color: rgba(255, 255, 255, 0.7);
-  font-weight: var(--font-weight-medium);
-  flex-shrink: 0;
+.date-strip__controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
 }
 
-/* ═══ Unified exercise list inside card ═══ */
-.training-card__exercises {
-  padding: var(--space-sm) var(--space-lg) var(--space-lg);
+.date-strip__scroll {
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  scroll-behavior: smooth;
 }
 
-.training-card__exercise-row {
+.date-strip__days {
   display: flex;
   justify-content: space-between;
+  gap: var(--space-sm);
+  min-width: 100%;
+}
+
+.date-strip__day {
+  position: relative;
+  display: flex;
+  flex: 1 0 46px;
+  min-width: 46px;
+  min-height: 64px;
+  flex-direction: column;
   align-items: center;
-  padding: var(--space-md) 0;
-  border-bottom: 1px solid var(--color-border-subtle);
-}
-
-.training-card__exercise-row:last-child {
-  border-bottom: none;
-}
-
-.training-card__exercise-name {
-  font-size: var(--font-size-base);
-  color: var(--color-text-primary);
-}
-
-.training-card__exercise-sets {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-  flex-shrink: 0;
-}
-
-/* Superset grouping */
-.training-card__superset {
-  background: var(--color-accent-subtle);
-  border-radius: var(--radius-md);
-  margin: var(--space-sm) 0;
-  padding: var(--space-sm) var(--space-md);
-}
-
-.training-card__superset-label {
-  font-size: var(--font-size-xs);
-  color: var(--color-accent-blue);
-  font-weight: var(--font-weight-semibold);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  margin-bottom: var(--space-xs);
-}
-
-.training-card__superset .training-card__exercise-row {
-  border-color: rgba(99, 102, 241, 0.15);
-}
-
-/* ═══ Celebration completed state ═══ */
-.training-card__celebration {
-  padding: var(--space-3xl) var(--space-xl) var(--space-xl);
+  justify-content: center;
+  gap: var(--space-1);
+  padding: var(--space-sm) var(--space-xs);
+  border: 1px solid transparent;
+  border-radius: var(--radius-lg);
+  background: transparent;
+  color: var(--text-secondary);
   text-align: center;
-  color: var(--color-accent-green);
+}
+
+.date-strip__day:hover {
+  border-color: var(--border);
+  background: var(--surface-high);
+}
+
+.date-strip__day:active {
+  transform: scale(0.97);
+}
+
+.date-strip__weekday {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 650;
+  line-height: 1;
+}
+
+.date-strip__day-number {
+  font-size: var(--text-lg);
+  font-weight: 750;
+  font-feature-settings: 'tnum' 1;
+  line-height: 1.1;
+}
+
+.date-strip__day-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  color: var(--accent-text);
+  font-size: var(--text-xs);
+  font-weight: 800;
+  line-height: 1;
+}
+
+.date-strip__day--completed {
+  color: var(--success);
+}
+
+.date-strip__day--completed .date-strip__day-indicator {
+  color: var(--success);
+}
+
+.date-strip__day--today::after {
+  content: '';
+  position: absolute;
+  right: 8px;
+  top: 8px;
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-full);
+  background: var(--accent);
+}
+
+.date-strip__day--selected {
+  border-color: color-mix(in oklch, var(--accent) 72%, transparent);
+  background: var(--accent);
+  color: var(--on-accent);
+  box-shadow: var(--glow-accent);
+}
+
+.date-strip__day--selected .date-strip__weekday,
+.date-strip__day--selected .date-strip__day-indicator,
+.date-strip__day--selected.date-strip__day--completed,
+.date-strip__day--selected.date-strip__day--completed .date-strip__day-indicator {
+  color: var(--on-accent);
+}
+
+.date-strip__day--selected.date-strip__day--today::after {
+  background: var(--on-accent);
+}
+
+/* ========== Scheduled workout hero ========== */
+.workout-preview-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  margin: 0;
+  padding: var(--space-xl);
+  border-color: var(--border);
+  border-radius: var(--radius-2xl);
+  background:
+    linear-gradient(180deg, color-mix(in oklch, var(--surface-elevated) 78%, transparent), transparent 58%),
+    var(--surface);
+  box-shadow: var(--shadow-md);
+}
+
+.workout-preview-card__topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.workout-preview-card__badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  min-height: 32px;
+  padding: var(--space-xs) var(--space-md);
+  border: 1px solid var(--accent-line);
+  border-radius: var(--radius-full);
+  background: var(--accent-subtle);
+  color: var(--accent-text);
+  font-size: var(--text-sm);
+  font-weight: 700;
+}
+
+.workout-preview-card__save {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  min-height: 36px;
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: var(--surface-high);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 700;
+}
+
+.workout-preview-card__save:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
+}
+
+.workout-preview-card__title {
+  margin: 0;
+  color: var(--text);
+  font-size: var(--text-3xl);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1.03;
+  text-wrap: balance;
+}
+
+.workout-preview-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-sm);
+}
+
+.workout-preview-card__metric {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-md);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-high);
+}
+
+.workout-preview-card__metric-value {
+  color: var(--text);
+  font-size: var(--text-xl);
+  font-weight: 800;
+  font-feature-settings: 'tnum' 1;
+  line-height: 1;
+}
+
+.workout-preview-card__metric-label {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 650;
+}
+
+.workout-preview-card__start,
+.tpl-preview__start-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  min-height: 56px;
+  border-radius: var(--radius-lg);
+  background: var(--accent);
+  color: var(--on-accent);
+  font-size: var(--text-lg);
+  font-weight: 800;
+  box-shadow: var(--glow-accent);
+}
+
+.workout-preview-card__start:hover,
+.tpl-preview__start-btn:hover {
+  background: var(--accent-hover);
+}
+
+.workout-preview-card__start:active,
+.tpl-preview__start-btn:active {
+  transform: scale(0.97);
+  background: var(--accent-press);
+  box-shadow: none;
+}
+
+.workout-preview-card__notes {
+  padding: var(--space-md);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--surface-high) 58%, transparent);
+}
+
+.workout-preview-card__notes-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  margin-bottom: var(--space-xs);
+  color: var(--accent-text);
+  font-size: var(--text-sm);
+  font-weight: 700;
+}
+
+.workout-preview-card__notes p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  text-wrap: pretty;
+}
+
+.workout-preview-card__exercises {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.workout-preview-card__block {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr);
+  gap: var(--space-md);
+  padding: var(--space-md);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: color-mix(in oklch, var(--surface-high) 42%, transparent);
+}
+
+.workout-preview-card__block--superset {
+  border-color: var(--accent-line);
+  background: var(--accent-subtle);
+}
+
+.workout-preview-card__block-label {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+  min-width: 0;
+}
+
+.workout-preview-card__block-label span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  background: var(--surface);
+  color: var(--accent-text);
+  font-size: var(--text-sm);
+  font-weight: 800;
+}
+
+.workout-preview-card__block-label strong {
+  color: var(--accent-text);
+  font-size: 0.6875rem;
+  font-weight: 750;
+  line-height: 1.1;
+  text-align: center;
+}
+
+.workout-preview-card__block-exercises {
+  min-width: 0;
+}
+
+.workout-preview-card__exercise-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-md);
+  min-width: 0;
+  padding: var(--space-sm) 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.workout-preview-card__exercise-row:first-child {
+  padding-top: 0;
+}
+
+.workout-preview-card__exercise-row:last-child {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+.workout-preview-card__exercise-name {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-size: var(--text-md);
+  font-weight: 650;
+}
+
+.workout-preview-card__exercise-sets {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-feature-settings: 'tnum' 1;
+}
+
+/* ========== Completed workout state ========== */
+.training-card {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2xl);
+  background: var(--surface);
+  box-shadow: var(--shadow-md);
+}
+
+.training-card--completed {
+  border-color: color-mix(in oklch, var(--success) 30%, var(--border));
+}
+
+.training-card__celebration {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--space-2xl) var(--space-xl) var(--space-xl);
+  color: var(--success);
+  text-align: center;
 }
 
 .training-card__celebration-title {
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-text-primary);
   margin: var(--space-md) 0 var(--space-xs);
+  color: var(--text);
+  font-size: var(--text-2xl);
+  font-weight: 800;
+  letter-spacing: -0.03em;
 }
 
 .training-card__celebration-sub {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  text-wrap: balance;
 }
 
 .training-card__stats-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
-  gap: var(--space-md);
-  padding: 0 var(--space-xl) var(--space-lg);
+  grid-template-columns: repeat(auto-fit, minmax(82px, 1fr));
+  gap: var(--space-sm);
+  padding: 0 var(--space-lg) var(--space-lg);
 }
 
 .training-card__stat-item {
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
   padding: var(--space-md);
-  background: var(--color-bg);
+  border: 1px solid var(--border-subtle);
   border-radius: var(--radius-md);
+  background: var(--surface-high);
 }
 
 .training-card__stat-value {
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-accent-green);
+  color: var(--success);
+  font-family: var(--font-mono);
+  font-size: var(--text-xl);
+  font-weight: 800;
+  font-feature-settings: 'tnum' 1, 'zero' 1;
+  line-height: 1;
 }
 
 .training-card__stat-label {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 650;
 }
 
 .training-card__motivation {
-  text-align: center;
-  padding: 0 var(--space-xl) var(--space-xl);
-  font-size: var(--font-size-base);
-  color: var(--color-text-secondary);
   margin: 0;
-}
-
-/* ═══ Sticky CTA ═══ */
-.training-sticky-cta {
-  position: fixed;
-  bottom: calc(72px + env(safe-area-inset-bottom, 0px));
-  left: var(--space-lg);
-  right: var(--space-lg);
-  z-index: 50;
-  padding-top: var(--space-xl);
-  background: linear-gradient(to top, var(--color-bg) 70%, transparent);
-  pointer-events: none;
-}
-
-.training-sticky-cta__btn {
-  width: 100%;
-  min-height: 56px;
-  font-size: var(--font-size-lg);
-  font-weight: var(--font-weight-semibold);
-  border-radius: var(--radius-lg);
-  background: linear-gradient(135deg, var(--color-accent-blue), var(--color-accent-hover));
-  color: white;
-  border: none;
-  cursor: pointer;
-  transition: all var(--transition);
-  box-shadow: 0 4px 20px rgba(99, 102, 241, 0.3);
-  pointer-events: auto;
-}
-
-.training-sticky-cta__btn:active {
-  transform: scale(0.97);
-  box-shadow: 0 2px 12px rgba(99, 102, 241, 0.4);
-}
-
-/* ========== Rest Day Card ========== */
-.training-rest-card {
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-xl);
-  padding: var(--space-3xl) var(--space-xl);
+  padding: 0 var(--space-xl) var(--space-xl);
+  color: var(--text-secondary);
+  font-size: var(--text-md);
+  font-weight: 650;
   text-align: center;
+}
+
+/* ========== Rest day ========== */
+.training-rest-card {
   display: flex;
   flex-direction: column;
   align-items: center;
-  box-shadow: var(--shadow-card);
+  gap: var(--space-md);
+  padding: var(--space-2xl) var(--space-xl);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2xl);
+  background: var(--surface);
+  box-shadow: var(--shadow-md);
+  text-align: center;
 }
 
 .training-rest-card__icon {
-  color: var(--color-text-muted);
-  margin-bottom: var(--space-lg);
-  opacity: 0.7;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: var(--surface-high);
+  color: var(--text-muted);
 }
 
 .training-rest-card__heading {
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-bold);
-  color: var(--color-text-muted);
-  margin: 0 0 var(--space-sm);
+  margin: var(--space-xs) 0 0;
+  color: var(--text);
+  font-size: var(--text-2xl);
+  font-weight: 800;
+  letter-spacing: -0.03em;
 }
 
 .training-rest-card__message {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
-  margin: 0;
-  max-width: 260px;
-  line-height: 1.5;
-}
-
-/* Up next preview */
-.training-rest-card__next {
-  display: flex;
-  align-items: center;
-  gap: var(--space-sm);
-  margin-top: var(--space-xl);
-  padding: var(--space-md) var(--space-lg);
-  background: var(--color-bg);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--color-border);
-  width: 100%;
   max-width: 300px;
-}
-
-.training-rest-card__next-label {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  flex-shrink: 0;
-}
-
-.training-rest-card__next-title {
-  font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-accent-blue);
-  flex: 1;
-}
-
-.training-rest-card__next-day {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-secondary);
-  flex-shrink: 0;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-md);
+  line-height: 1.5;
+  text-wrap: pretty;
 }
 
 .training-rest-card__plan-btn {
-  margin-top: var(--space-xl);
+  margin-top: var(--space-xs);
 }
 
-/* ========== WorkoutPreviewCard (moved from components.css) ========== */
-.workout-preview-card__coach-avatar {
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  background-color: var(--color-border);
+.training-rest-card__next {
   display: flex;
   align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  color: var(--color-text-primary);
-  font-size: var(--font-size-sm);
+  gap: var(--space-md);
+  width: 100%;
+  margin-top: var(--space-sm);
+  padding: var(--space-md);
+  border: 1px solid var(--accent-line);
+  border-radius: var(--radius-lg);
+  background: var(--accent-subtle);
+  text-align: left;
 }
 
-.workout-preview-card__title {
-  font-size: var(--font-size-xl);
-  line-height: 1.3;
+.training-rest-card__next-label {
+  flex-shrink: 0;
+  color: var(--accent-text);
+  font-size: var(--text-xs);
+  font-weight: 800;
+}
+
+.training-rest-card__next-main {
+  display: flex;
+  min-width: 0;
+  flex: 1;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.training-rest-card__next-title {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-size: var(--text-md);
+  font-weight: 750;
+  line-height: 1.25;
+}
+
+.training-rest-card__next-day {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-feature-settings: 'tnum' 1;
+}
+
+/* ========== Quick start ========== */
+.training-templates {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.training-templates__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-md);
+  color: var(--accent-text);
+}
+
+.training-templates__title {
+  margin: 0;
+  color: var(--text);
+  font-size: var(--text-xl);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.training-templates__subtext {
+  margin: var(--space-1) 0 0;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.training-templates__scroll {
+  display: flex;
+  gap: var(--space-md);
+  margin-inline: calc(-1 * var(--space-lg));
+  padding-inline: var(--space-lg);
+  padding-bottom: var(--space-xs);
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: x proximity;
+}
+
+.training-templates__card {
+  display: flex;
+  flex: 0 0 min(76vw, 220px);
+  flex-direction: column;
+  gap: var(--space-sm);
+  min-height: 166px;
+  padding: var(--space-lg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  background: var(--surface);
+  color: var(--text);
+  text-align: left;
+  scroll-snap-align: start;
+  box-shadow: var(--shadow-sm);
+}
+
+.training-templates__card:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-1px);
+}
+
+.training-templates__card:active {
+  transform: scale(0.98);
+}
+
+.training-templates__card-kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  width: fit-content;
+  color: var(--accent-text);
+  font-size: var(--text-xs);
+  font-weight: 800;
+}
+
+.training-templates__card-name {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--text);
+  font-size: var(--text-lg);
+  font-weight: 800;
+  line-height: 1.15;
+  text-wrap: balance;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.training-templates__card-meta {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-feature-settings: 'tnum' 1;
+}
+
+.training-templates__card-exercises {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.35;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 /* ========== Template Preview Sheet ========== */
 .tpl-preview-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  backdrop-filter: blur(4px);
-  -webkit-backdrop-filter: blur(4px);
-  z-index: 200;
+  z-index: var(--z-backdrop);
   display: flex;
   align-items: flex-end;
   justify-content: center;
-  animation: tpl-fade-in 200ms ease;
+  padding-inline: max(var(--space-sm), env(safe-area-inset-left));
+  background: rgba(0, 0, 0, 0.6);
+  animation: tpl-fade-in var(--dur) var(--ease-out-quart);
 }
 
 @keyframes tpl-fade-in {
@@ -321,219 +742,225 @@
 }
 
 .tpl-preview-sheet {
-  width: 100%;
-  max-width: 500px;
-  max-height: 80vh;
-  background: var(--color-surface);
-  border-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  width: min(100%, var(--app-max-width));
+  max-height: min(82vh, 720px);
   overflow-y: auto;
-  animation: tpl-slide-up 300ms ease;
-  padding-bottom: env(safe-area-inset-bottom, var(--space-lg));
+  border: 1px solid var(--border);
+  border-bottom: 0;
+  border-radius: var(--radius-2xl) var(--radius-2xl) 0 0;
+  background: var(--surface-elevated);
+  box-shadow: var(--shadow-lg);
+  animation: tpl-slide-up var(--dur-slow) var(--ease-out-expo);
+  padding-bottom: max(var(--space-lg), env(safe-area-inset-bottom));
 }
 
 @keyframes tpl-slide-up {
-  from { transform: translateY(100%); }
+  from { transform: translateY(18px); }
   to { transform: translateY(0); }
 }
 
+.tpl-preview__grabber {
+  width: 44px;
+  height: 5px;
+  margin: var(--space-sm) auto var(--space-xs);
+  border-radius: var(--radius-full);
+  background: var(--border-strong);
+}
+
 .tpl-preview__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: var(--space-xl) var(--space-lg) var(--space-sm);
   position: sticky;
   top: 0;
-  background: var(--color-surface);
   z-index: 1;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  padding: var(--space-md) var(--space-lg) var(--space-sm);
+  background: var(--surface-elevated);
+}
+
+.tpl-preview__kicker {
+  color: var(--accent-text);
+  font-size: var(--text-sm);
+  font-weight: 750;
 }
 
 .tpl-preview__title {
-  font-size: var(--font-size-xl);
-  font-weight: var(--font-weight-bold);
-  margin: 0;
+  margin: var(--space-1) 0 0;
+  color: var(--text);
+  font-size: var(--text-2xl);
+  font-weight: 800;
+  letter-spacing: -0.04em;
+  line-height: 1.08;
+  text-wrap: balance;
 }
 
 .tpl-preview__close {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: var(--color-surface-elevated);
-  border: none;
+  flex-shrink: 0;
+  width: 40px;
+  height: 40px;
+  border: 1px solid var(--border);
   border-radius: var(--radius-full);
-  width: 32px;
-  height: 32px;
-  color: var(--color-text-secondary);
-  cursor: pointer;
+  background: var(--surface-high);
+  color: var(--text-secondary);
+}
+
+.tpl-preview__close:hover {
+  border-color: var(--border-strong);
+  color: var(--text);
 }
 
 .tpl-preview__meta {
-  padding: 0 var(--space-lg);
-  font-size: var(--font-size-sm);
-  color: var(--color-text-secondary);
-  margin-bottom: var(--space-lg);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  padding: 0 var(--space-lg) var(--space-lg);
+}
+
+.tpl-preview__meta span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: var(--space-xs) var(--space-md);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-full);
+  background: var(--surface-high);
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 650;
+  font-feature-settings: 'tnum' 1;
 }
 
 .tpl-preview__exercises {
-  padding: 0 var(--space-lg);
-  margin-bottom: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: 0 var(--space-lg) var(--space-lg);
+}
+
+.tpl-preview__block {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: var(--space-md);
+  padding: var(--space-md);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+}
+
+.tpl-preview__block--superset {
+  border-color: var(--accent-line);
+  background: var(--accent-subtle);
+}
+
+.tpl-preview__block-heading {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.tpl-preview__block-letter {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-full);
+  background: var(--surface-high);
+  color: var(--accent-text);
+  font-size: var(--text-sm);
+  font-weight: 800;
 }
 
 .tpl-preview__superset-label {
-  font-size: var(--font-size-xs);
-  color: var(--color-accent-blue);
-  font-weight: var(--font-weight-semibold);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: var(--space-sm) 0 var(--space-xs);
+  color: var(--accent-text);
+  font-size: 0.6875rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+.tpl-preview__block-list {
+  min-width: 0;
 }
 
 .tpl-preview__exercise-row {
   display: flex;
+  align-items: baseline;
   justify-content: space-between;
-  align-items: center;
-  padding: var(--space-md) 0;
-  border-bottom: 1px solid var(--color-border-subtle);
+  gap: var(--space-md);
+  min-width: 0;
+  padding: var(--space-sm) 0;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.tpl-preview__exercise-row:first-child {
+  padding-top: 0;
 }
 
 .tpl-preview__exercise-row:last-child {
-  border-bottom: none;
+  padding-bottom: 0;
+  border-bottom: 0;
 }
 
 .tpl-preview__exercise-name {
-  font-size: var(--font-size-base);
-  color: var(--color-text-primary);
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--text);
+  font-size: var(--text-md);
+  font-weight: 650;
 }
 
 .tpl-preview__exercise-sets {
-  font-size: var(--font-size-sm);
-  color: var(--color-text-muted);
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  font-feature-settings: 'tnum' 1;
 }
 
-/* Actions */
 .tpl-preview__actions {
-  display: flex;
+  position: sticky;
+  bottom: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(0, 1fr);
   gap: var(--space-md);
   padding: var(--space-lg);
-}
-
-.tpl-preview__start-btn {
-  flex: 2;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-sm);
-  min-height: 52px;
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
-  border: none;
-  border-radius: var(--radius-lg);
-  background: linear-gradient(135deg, var(--color-accent-blue), var(--color-accent-hover));
-  color: white;
-  cursor: pointer;
-  transition: all var(--transition);
-}
-
-.tpl-preview__start-btn:active {
-  transform: scale(0.97);
+  border-top: 1px solid var(--border-subtle);
+  background: var(--surface-elevated);
 }
 
 .tpl-preview__schedule-btn {
-  flex: 1;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: var(--space-sm);
-  min-height: 52px;
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-medium);
-  border: 1px solid var(--color-border);
+  min-height: 56px;
+  border: 1px solid var(--border);
   border-radius: var(--radius-lg);
-  background: var(--color-surface);
-  color: var(--color-text-primary);
-  cursor: pointer;
-  transition: all var(--transition);
+  background: var(--surface-high);
+  color: var(--text);
+  font-size: var(--text-md);
+  font-weight: 750;
+}
+
+.tpl-preview__schedule-btn:hover {
+  border-color: var(--border-strong);
+  background: var(--surface);
 }
 
 .tpl-preview__schedule-btn:active {
-  background: var(--color-surface-elevated);
   transform: scale(0.97);
 }
 
-/* ========== Home Screen Template Cards ========== */
-.training-templates {
-  margin-top: var(--space-xl);
-}
+@media (max-width: 380px) {
+  .workout-preview-card__metrics {
+    grid-template-columns: 1fr;
+  }
 
-.training-templates__label {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-weight: var(--font-weight-semibold);
-  margin-bottom: var(--space-md);
-}
-
-.training-templates__scroll {
-  display: flex;
-  gap: var(--space-md);
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  scroll-snap-type: x proximity;
-  padding-bottom: var(--space-sm);
-  margin: 0 calc(-1 * var(--space-lg));
-  padding-left: var(--space-lg);
-  padding-right: var(--space-lg);
-}
-
-.training-templates__scroll::-webkit-scrollbar {
-  display: none;
-}
-
-.training-templates__card {
-  flex: 0 0 auto;
-  width: 160px;
-  padding: var(--space-lg);
-  background: var(--color-surface);
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-lg);
-  cursor: pointer;
-  scroll-snap-align: start;
-  transition: all var(--transition);
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-xs);
-}
-
-.training-templates__card:active {
-  transform: scale(0.97);
-  border-color: var(--color-accent-blue);
-}
-
-.training-templates__card-name {
-  font-size: var(--font-size-base);
-  font-weight: var(--font-weight-semibold);
-  color: var(--color-text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.training-templates__card-meta {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-muted);
-}
-
-.training-templates__card-exercises {
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  margin-top: var(--space-xs);
-}
-
-.training-templates__card-exercise {
-  font-size: 12px;
-  color: var(--color-text-secondary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  .tpl-preview__actions {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/styles/training.css
+++ b/src/styles/training.css
@@ -932,6 +932,22 @@
   background: var(--surface-elevated);
 }
 
+.tpl-preview__start-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+  box-shadow: none;
+  transform: none;
+}
+
+.tpl-preview__start-note {
+  grid-column: 1 / -1;
+  grid-row: 2;
+  margin: calc(-1 * var(--space-xs)) 0 0;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  line-height: 1.35;
+}
+
 .tpl-preview__schedule-btn {
   display: inline-flex;
   align-items: center;

--- a/src/views/TrainingView.jsx
+++ b/src/views/TrainingView.jsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
-import { CalendarRange, Moon, CheckCircle2, Flame } from 'lucide-react';
+import { CalendarRange, CheckCircle2, Flame, Moon, Play, Sparkles } from 'lucide-react';
 import { ROUTE_PLANNER } from '../constants';
 import DateStrip from '../components/DateStrip';
 import MonthCalendar from '../components/MonthCalendar';
 import TemplatePreviewSheet from '../components/TemplatePreviewSheet';
+import WorkoutPreviewCard from '../components/WorkoutPreviewCard';
 import { calculateStreaks } from '../utils/streaks';
 
 function getGreeting() {
@@ -30,6 +31,26 @@ function formatDayLabel(daysAway) {
   if (daysAway === 1) return 'Tomorrow';
   if (daysAway === 2) return 'In 2 days';
   return `In ${daysAway} days`;
+}
+
+function formatSelectedDate(dateStr) {
+  const [year, month, day] = dateStr.split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function getTemplateExercises(template) {
+  return (template.blocks || []).flatMap((block) => block.exercises || []);
+}
+
+function getTemplateSetCount(template) {
+  return getTemplateExercises(template).reduce(
+    (sum, exercise) => sum + (exercise.sets?.length || 0),
+    0
+  );
 }
 
 export default function TrainingView({
@@ -85,13 +106,18 @@ export default function TrainingView({
 
   return (
     <div className="view training-view">
-      {/* Greeting header */}
       <div className="training-greeting">
-        <h2 className="training-greeting__text">{getGreeting()}</h2>
+        <div className="training-greeting__copy">
+          <h1 className="training-greeting__text">{getGreeting()}</h1>
+          <p className="training-greeting__subtext">
+            {formatSelectedDate(currentDate)}
+          </p>
+        </div>
         {streakDisplay > 0 && (
           <span className="training-greeting__streak">
             <Flame size={16} />
-            {streakDisplay} day{streakDisplay !== 1 ? 's' : ''}
+            <span className="training-greeting__streak-count">{streakDisplay}</span>
+            <span>day{streakDisplay !== 1 ? 's' : ''}</span>
           </span>
         )}
       </div>
@@ -118,7 +144,7 @@ export default function TrainingView({
               className="btn btn-secondary btn-small"
               onClick={() => setViewMode('week')}
             >
-              <CalendarRange size={14} style={{ marginRight: 5, verticalAlign: 'middle' }} />
+              <CalendarRange size={14} />
               Week View
             </button>
           </div>
@@ -158,34 +184,10 @@ export default function TrainingView({
                 <p className="training-card__motivation">Crushed it 💪</p>
               </div>
             ) : (
-              <div className="training-card">
-                <div className="training-card__header">
-                  <h2 className="training-card__title">{workout.title}</h2>
-                  <span className="training-card__exercise-count">
-                    {workout.blocks.reduce((n, b) => n + b.exercises.length, 0)} exercises
-                  </span>
-                </div>
-                <div className="training-card__exercises">
-                  {workout.blocks.map((block, blockIdx) => {
-                    const isSuperset = block.exercises.length > 1;
-                    return (
-                      <div key={blockIdx} className={isSuperset ? 'training-card__superset' : undefined}>
-                        {isSuperset && (
-                          <div className="training-card__superset-label">Superset</div>
-                        )}
-                        {block.exercises.map((exercise, exIdx) => (
-                          <div key={exIdx} className="training-card__exercise-row">
-                            <span className="training-card__exercise-name">{exercise.title}</span>
-                            <span className="training-card__exercise-sets">
-                              {exercise.sets.length} set{exercise.sets.length !== 1 ? 's' : ''}
-                            </span>
-                          </div>
-                        ))}
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
+              <WorkoutPreviewCard
+                workout={workout}
+                onStartWorkout={handleStartWorkout}
+              />
             )}
           </>
         ) : (
@@ -207,66 +209,63 @@ export default function TrainingView({
               {nextWorkout && (
                 <div className="training-rest-card__next">
                   <span className="training-rest-card__next-label">Up next</span>
-                  <span className="training-rest-card__next-title">
-                    {nextWorkout.title}
-                  </span>
-                  <span className="training-rest-card__next-day">
-                    {formatDayLabel(nextWorkout.daysAway)}
-                  </span>
+                  <div className="training-rest-card__next-main">
+                    <span className="training-rest-card__next-title">
+                      {nextWorkout.title}
+                    </span>
+                    <span className="training-rest-card__next-day">
+                      {formatDayLabel(nextWorkout.daysAway)}
+                    </span>
+                  </div>
                 </div>
               )}
             </div>
-
-            {/* Template cards on rest days */}
-            {templateList && templateList.length > 0 && (
-              <div className="training-templates">
-                <div className="training-templates__label">Quick Start</div>
-                <div className="training-templates__scroll">
-                  {templateList.map((tpl) => {
-                    const exercises = tpl.blocks.flatMap((b) => b.exercises);
-                    return (
-                      <button
-                        key={tpl.id}
-                        className="training-templates__card"
-                        onClick={() => setPreviewTemplate(tpl)}
-                      >
-                        <span className="training-templates__card-name">{tpl.name}</span>
-                        <span className="training-templates__card-meta">
-                          {exercises.length} exercise{exercises.length !== 1 ? 's' : ''}
-                        </span>
-                        <div className="training-templates__card-exercises">
-                          {exercises.slice(0, 3).map((ex, i) => (
-                            <span key={i} className="training-templates__card-exercise">
-                              {ex.title}
-                            </span>
-                          ))}
-                          {exercises.length > 3 && (
-                            <span className="training-templates__card-exercise">
-                              +{exercises.length - 3} more
-                            </span>
-                          )}
-                        </div>
-                      </button>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
           </>
         )}
-      </div>
 
-      {/* Sticky CTA — only when workout exists and not completed */}
-      {workout && !isCompleted && (
-        <div className="training-sticky-cta">
-          <button
-            className="training-sticky-cta__btn"
-            onClick={handleStartWorkout}
-          >
-            Start Workout
-          </button>
-        </div>
-      )}
+        {templateList && templateList.length > 0 && (
+          <section className="training-templates" aria-labelledby="training-quick-start">
+            <div className="training-templates__header">
+              <div>
+                <h2 id="training-quick-start" className="training-templates__title">
+                  Quick Start
+                </h2>
+                <p className="training-templates__subtext">
+                  Preview a saved template and train on demand.
+                </p>
+              </div>
+              <Sparkles size={18} aria-hidden="true" />
+            </div>
+            <div className="training-templates__scroll">
+              {templateList.map((tpl) => {
+                const exercises = getTemplateExercises(tpl);
+                const setCount = getTemplateSetCount(tpl);
+                return (
+                  <button
+                    key={tpl.id}
+                    className="training-templates__card"
+                    onClick={() => setPreviewTemplate(tpl)}
+                    aria-label={`Preview ${tpl.name}`}
+                  >
+                    <span className="training-templates__card-kicker">
+                      <Play size={12} aria-hidden="true" />
+                      Template
+                    </span>
+                    <span className="training-templates__card-name">{tpl.name}</span>
+                    <span className="training-templates__card-meta">
+                      {exercises.length} exercise{exercises.length !== 1 ? 's' : ''} · {setCount} set{setCount !== 1 ? 's' : ''}
+                    </span>
+                    <span className="training-templates__card-exercises">
+                      {exercises.slice(0, 3).map((ex) => ex.title).join(' / ')}
+                      {exercises.length > 3 ? ` / +${exercises.length - 3} more` : ''}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+        )}
+      </div>
 
       {/* Template preview sheet */}
       {previewTemplate && (
@@ -275,6 +274,7 @@ export default function TrainingView({
           onStartNow={() => {
             if (onScheduleTemplate) {
               onScheduleTemplate(currentDate, previewTemplate.name);
+              onStartWorkout(`${currentDate}::${previewTemplate.name}`);
             }
             setPreviewTemplate(null);
           }}

--- a/src/views/TrainingView.jsx
+++ b/src/views/TrainingView.jsx
@@ -97,11 +97,14 @@ export default function TrainingView({
   })() : null;
 
   const nextWorkout = !workout ? findNextWorkout(schedule, currentDate) : null;
+  const dateHasCompletedLog = completedDates.has(currentDate);
   const quickStartBlockedReason = workoutTitle
     ? isCompleted
       ? 'This day already has a completed workout. Schedule this template for another day.'
       : 'This day already has a planned workout. Schedule this template for another day.'
-    : '';
+    : dateHasCompletedLog
+      ? 'This day already has a completed workout. Schedule this template for another day.'
+      : '';
 
   const handleStartWorkout = () => {
     if (workoutTitle) {

--- a/src/views/TrainingView.jsx
+++ b/src/views/TrainingView.jsx
@@ -97,6 +97,11 @@ export default function TrainingView({
   })() : null;
 
   const nextWorkout = !workout ? findNextWorkout(schedule, currentDate) : null;
+  const quickStartBlockedReason = workoutTitle
+    ? isCompleted
+      ? 'This day already has a completed workout. Schedule this template for another day.'
+      : 'This day already has a planned workout. Schedule this template for another day.'
+    : '';
 
   const handleStartWorkout = () => {
     if (workoutTitle) {
@@ -271,7 +276,9 @@ export default function TrainingView({
       {previewTemplate && (
         <TemplatePreviewSheet
           template={previewTemplate}
+          startDisabledReason={quickStartBlockedReason}
           onStartNow={() => {
+            if (quickStartBlockedReason) return;
             if (onScheduleTemplate) {
               onScheduleTemplate(currentDate, previewTemplate.name);
               onStartWorkout(`${currentDate}::${previewTemplate.name}`);

--- a/src/views/TrainingView.test.jsx
+++ b/src/views/TrainingView.test.jsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import TrainingView from './TrainingView.jsx';
+
+const COMPLETED_REASON = 'This day already has a completed workout. Schedule this template for another day.';
+
+const template = {
+  id: 'tpl_full_body',
+  name: 'Full Body Template',
+  blocks: [
+    {
+      value: 'A',
+      exercises: [
+        {
+          title: 'Bench Press',
+          sets: [{ reps: 5, weight: 135, unit: 'lb' }],
+        },
+      ],
+    },
+  ],
+};
+
+function renderTrainingView(overrides = {}) {
+  const props = {
+    currentDate: '2026-07-04',
+    onDateChange: vi.fn(),
+    workouts: {},
+    schedule: {},
+    completedDates: new Set(),
+    getWorkoutForDate: vi.fn(() => null),
+    getLog: vi.fn(() => null),
+    onStartWorkout: vi.fn(),
+    onScheduleTemplate: vi.fn(),
+    templateList: [template],
+    navigate: vi.fn(),
+    ...overrides,
+  };
+
+  return { ...render(<TrainingView {...props} />), props };
+}
+
+describe('TrainingView', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  it('blocks Quick Start on a completed date even when no workout is scheduled', () => {
+    const { props } = renderTrainingView({
+      completedDates: new Set(['2026-07-04']),
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Preview Full Body Template' }));
+
+    const startNow = screen.getByRole('button', { name: /start now/i });
+    expect(startNow.disabled).toBe(true);
+    expect(screen.getByText(COMPLETED_REASON)).toBeTruthy();
+
+    fireEvent.click(startNow);
+    expect(props.onScheduleTemplate).not.toHaveBeenCalled();
+    expect(props.onStartWorkout).not.toHaveBeenCalled();
+  });
+});

--- a/src/views/WeekPlannerView.jsx
+++ b/src/views/WeekPlannerView.jsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect } from 'react';
-import { ChevronLeft, ChevronRight } from 'lucide-react';
+import { CalendarCheck, ChevronLeft, ChevronRight, Search, X } from 'lucide-react';
 import Modal from '../components/Modal';
 
 const DAY_NAMES = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
@@ -177,9 +177,11 @@ export default function WeekPlannerView({
   return (
     <div className="view planner-view">
       <div className="planner-view__header">
-        <h1>Week Planner</h1>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-sm)' }}>
-          <p className="text-secondary text-sm">{formatWeekRange()}</p>
+        <div>
+          <h1>Week Planner</h1>
+          <p className="planner-view__range">{formatWeekRange()}</p>
+        </div>
+        <div className="planner-view__status-row">
           {hasDraftChanges && <span className="planner-draft-badge">Unsaved changes</span>}
         </div>
       </div>
@@ -197,11 +199,12 @@ export default function WeekPlannerView({
       </div>
 
       {templateList.length === 0 && (
-        <div className="empty-state" style={{ marginBottom: 'var(--space-md)' }}>
-          <p className="text-secondary text-sm">
-            No templates yet — save a workout as a template from the Training view to start planning.
-          </p>
+      <div className="planner-empty-state">
+        <div className="planner-empty-state__icon">
+          <CalendarCheck size={22} aria-hidden="true" />
         </div>
+        <p>No templates yet. Save a workout as a template to start planning.</p>
+      </div>
       )}
 
       <div className="planner-view__grid">
@@ -218,6 +221,7 @@ export default function WeekPlannerView({
               }`}
             >
               <div className="planner-day__header">
+                <span className="planner-day__marker" aria-hidden="true" />
                 <span className="planner-day__name">{DAY_NAMES[idx]}</span>
                 <span className="planner-day__date">
                   {parseLocalDate(dateStr).getDate()}
@@ -230,7 +234,7 @@ export default function WeekPlannerView({
                     className="planner-day__workout-name"
                     onClick={isDrafted ? undefined : () => onNavigateToDate(dateStr)}
                     title={isDrafted ? undefined : 'Go to workout'}
-                    style={{ opacity: isDrafted ? 0.7 : 1 }}
+                    disabled={isDrafted}
                   >
                     {workoutName}
                   </button>
@@ -239,7 +243,7 @@ export default function WeekPlannerView({
                     onClick={() => clearDay(dateStr)}
                     title="Remove workout"
                   >
-                    ✕
+                    <X size={16} aria-hidden="true" />
                   </button>
                 </div>
               ) : (
@@ -285,14 +289,25 @@ export default function WeekPlannerView({
       {showPicker && (
         <div className="modal-overlay" onClick={() => { setShowPicker(null); setTemplateSearch(''); }}>
           <div className="modal template-picker" onClick={(e) => e.stopPropagation()}>
-            <h2 className="modal__title">Pick a Template</h2>
-            <p className="modal__message">
-              {DAY_NAMES[weekDates.indexOf(showPicker)]},{' '}
-              {parseLocalDate(showPicker).toLocaleDateString('en-US', {
-                month: 'short',
-                day: 'numeric',
-              })}
-            </p>
+            <div className="template-picker__header">
+              <div>
+                <h2 className="modal__title">Pick a Template</h2>
+                <p className="modal__message">
+                  {DAY_NAMES[weekDates.indexOf(showPicker)]},{' '}
+                  {parseLocalDate(showPicker).toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                  })}
+                </p>
+              </div>
+              <button
+                className="template-picker__close"
+                onClick={() => { setShowPicker(null); setTemplateSearch(''); }}
+                aria-label="Close template picker"
+              >
+                <X size={18} />
+              </button>
+            </div>
 
             {templateList.length === 0 ? (
               <div className="empty-state">
@@ -302,14 +317,16 @@ export default function WeekPlannerView({
               </div>
             ) : (
               <>
-                <input
-                  type="text"
-                  className="input"
-                  placeholder="Search templates..."
-                  value={templateSearch}
-                  onChange={(e) => setTemplateSearch(e.target.value)}
-                  style={{ marginBottom: 'var(--space-sm)' }}
-                />
+                <label className="template-picker__search">
+                  <Search size={16} aria-hidden="true" />
+                  <input
+                    type="text"
+                    className="input"
+                    placeholder="Search templates..."
+                    value={templateSearch}
+                    onChange={(e) => setTemplateSearch(e.target.value)}
+                  />
+                </label>
                 <div className="template-picker__list">
                   {templateList
                     .filter((tpl) =>
@@ -322,12 +339,8 @@ export default function WeekPlannerView({
                         onClick={() => assignTemplate(showPicker, tpl.id)}
                       >
                         <span className="template-picker__name">{tpl.name}</span>
-                        <span className="template-picker__meta text-secondary text-sm">
-                          {tpl.blocks.reduce(
-                            (sum, b) => sum + b.exercises.length,
-                            0
-                          )}{' '}
-                          exercises
+                        <span className="template-picker__meta">
+                          {tpl.blocks.reduce((sum, b) => sum + b.exercises.length, 0)} exercises
                         </span>
                       </button>
                     ))}


### PR DESCRIPTION
## Summary
- Redesign Training home, DateStrip, WorkoutPreviewCard, rest day, Quick Start, and TemplatePreviewSheet for Focused Athletic Dark
- Redesign MonthCalendar and Week Planner states with tokenized violet/semantic indicators and no side-stripe accents
- Preserve A1 data flow/props while improving Start Now scheduling from template preview

## Validation
- npx vitest run --reporter=dot
- npm run build
- Seeded demo visual QA at 402x874 and desktop 1280px