### PR TITLE
Move templates into the Library as a tab

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,7 +21,6 @@ import {
   ROUTE_EDIT_TEMPLATE,
   ROUTE_EXERCISE_HISTORY,
   ROUTE_STATS,
-  ROUTE_TEMPLATES,
   parseLogKey,
 } from './constants';
 
@@ -33,7 +32,6 @@ import LibraryView from './views/LibraryView';
 import WeekPlannerView from './views/WeekPlannerView';
 import SettingsView from './views/SettingsView';
 import TemplateEditorView from './views/TemplateEditorView';
-import TemplateListView from './views/TemplateListView';
 import ExerciseHistoryView from './views/ExerciseHistoryView';
 import StatsView from './views/StatsView';
 import Modal from './components/Modal';
@@ -333,6 +331,10 @@ export default function App() {
           onUpdateExerciseNotes={(exerciseTitle, notes) =>
             applyWrites(applyNoteChange(snap(), exerciseTitle, notes))
           }
+          templateList={templateList}
+          deleteTemplate={handleDeleteTemplate}
+          navigate={navigate}
+          initialTab={params.tab}
         />
       );
       break;
@@ -402,16 +404,6 @@ export default function App() {
       );
       break;
 
-    case ROUTE_TEMPLATES:
-      currentView = (
-        <TemplateListView
-          templateList={templateList}
-          deleteTemplate={handleDeleteTemplate}
-          navigate={navigate}
-        />
-      );
-      break;
-
     case ROUTE_EDIT_TEMPLATE: {
       const tpl = templates[params.templateId];
       // Build exercise names list from all workouts
@@ -434,11 +426,11 @@ export default function App() {
               previousName: tpl.name,
             }));
             if (ok) {
-              navigate(ROUTE_TEMPLATES);
+              navigate(ROUTE_LIBRARY, { tab: 'templates' });
               showToast('Template saved!');
             }
           }}
-          onCancel={() => navigate(ROUTE_TEMPLATES)}
+          onCancel={() => navigate(ROUTE_LIBRARY, { tab: 'templates' })}
         />
       ) : (
         <SettingsView

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -205,6 +205,13 @@ export default function App() {
     history.pushState({ view, params }, '');
   }, []);
 
+  // Persist the Library's active tab into the current history entry so that
+  // returning via browser Back (e.g. from the template editor) restores it.
+  const handleLibraryTabChange = useCallback((tab) => {
+    const current = history.state && history.state.params ? history.state.params : {};
+    history.replaceState({ view: ROUTE_LIBRARY, params: { ...current, tab } }, '');
+  }, []);
+
   // Handle resume modal
   const handleResumeYes = () => {
     setShowResumeModal(false);
@@ -335,6 +342,7 @@ export default function App() {
           deleteTemplate={handleDeleteTemplate}
           navigate={navigate}
           initialTab={params.tab}
+          onTabChange={handleLibraryTabChange}
         />
       );
       break;

--- a/src/constants.js
+++ b/src/constants.js
@@ -17,7 +17,6 @@ export const ROUTE_SETTINGS = 'settings';
 export const ROUTE_EDIT_TEMPLATE = 'editTemplate';
 export const ROUTE_EXERCISE_HISTORY = 'exerciseHistory';
 export const ROUTE_STATS = 'stats';
-export const ROUTE_TEMPLATES = 'templates';
 
 // Tab IDs for bottom nav
 export const TAB_TRAINING = 'training';

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -66,6 +66,56 @@
   font-weight: 600;
 }
 
+/* Exercises / Templates segmented tabs */
+.library-view__tabs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-xs);
+  margin: 0 var(--space-lg) var(--space-sm);
+  padding: var(--space-xs);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-full);
+  background: var(--surface-high);
+}
+
+.library-view__tab {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  min-height: 40px;
+  padding: 0 var(--space-sm);
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 750;
+  line-height: 1;
+}
+
+.library-view__tab:hover {
+  color: var(--text);
+  background: color-mix(in oklch, var(--surface-elevated) 64%, transparent);
+}
+
+.library-view__tab:active {
+  transform: scale(0.98);
+}
+
+.library-view__tab:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px var(--accent-subtle);
+}
+
+.library-view__tab--active,
+.library-view__tab--active:hover {
+  border-color: var(--accent-line);
+  background: var(--accent-subtle);
+  color: var(--text);
+}
+
 .library-view__search-bar {
   position: sticky;
   top: 0;

--- a/src/views/LibraryView.jsx
+++ b/src/views/LibraryView.jsx
@@ -94,8 +94,12 @@ function formatSetSummary(exercise) {
   return `${sets.length} set${sets.length !== 1 ? 's' : ''}`;
 }
 
-export default function LibraryView({ workouts, youtubeLinks, setYouTubeLink, setManyYouTubeLinks, onUpdateExerciseNotes, onExerciseTap, templateList = [], deleteTemplate, navigate, initialTab }) {
-  const [tab, setTab] = useState(initialTab === 'templates' ? 'templates' : 'exercises');
+export default function LibraryView({ workouts, youtubeLinks, setYouTubeLink, setManyYouTubeLinks, onUpdateExerciseNotes, onExerciseTap, templateList = [], deleteTemplate, navigate, initialTab, onTabChange }) {
+  const [tab, setTabState] = useState(initialTab === 'templates' ? 'templates' : 'exercises');
+  const setTab = (next) => {
+    setTabState(next);
+    onTabChange?.(next);
+  };
   const [search, setSearch] = useState('');
   const [expandedExercise, setExpandedExercise] = useState(null);
   const [editingNotes, setEditingNotes] = useState(null);

--- a/src/views/LibraryView.jsx
+++ b/src/views/LibraryView.jsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
-import { AlertTriangle, BookOpen, Check, ChevronDown, ChevronRight, Loader, Play, Search, Upload, X } from 'lucide-react';
+import { AlertTriangle, BookOpen, Check, ChevronDown, ChevronRight, Layers3, Loader, Play, Search, Upload, X } from 'lucide-react';
 import YouTubeLinkInput, { isValidYouTubeUrl } from '../components/YouTubeLinkInput';
+import TemplateListView from './TemplateListView';
 
 const YOUTUBE_URL_RE = /^https?:\/\/(www\.)?(youtube\.com|youtu\.be)\/[^\s]*/i;
 
@@ -93,7 +94,8 @@ function formatSetSummary(exercise) {
   return `${sets.length} set${sets.length !== 1 ? 's' : ''}`;
 }
 
-export default function LibraryView({ workouts, youtubeLinks, setYouTubeLink, setManyYouTubeLinks, onUpdateExerciseNotes, onExerciseTap }) {
+export default function LibraryView({ workouts, youtubeLinks, setYouTubeLink, setManyYouTubeLinks, onUpdateExerciseNotes, onExerciseTap, templateList = [], deleteTemplate, navigate, initialTab }) {
+  const [tab, setTab] = useState(initialTab === 'templates' ? 'templates' : 'exercises');
   const [search, setSearch] = useState('');
   const [expandedExercise, setExpandedExercise] = useState(null);
   const [editingNotes, setEditingNotes] = useState(null);
@@ -218,40 +220,64 @@ export default function LibraryView({ workouts, youtubeLinks, setYouTubeLink, se
     setPreImportLinks(null);
   };
 
-  if (Object.keys(workouts).length === 0) {
-    return (
-      <div className="view library-view">
-        <div className="library-view__header">
-          <div className="library-view__header-icon" aria-hidden="true">
-            <BookOpen size={26} />
-          </div>
-          <h1>Exercise Library</h1>
-          <p className="text-secondary text-sm">Import a workout to populate your exercise list, form cues, and reference videos.</p>
-        </div>
-        <div className="empty-state">
-          <div className="empty-state-icon"><BookOpen size={48} /></div>
-          <h3>No exercises yet</h3>
-          <p className="text-secondary">Import a workout to populate your library</p>
-        </div>
-      </div>
-    );
-  }
+  const hasWorkouts = Object.keys(workouts).length > 0;
 
   return (
     <div className="view library-view">
       <div className="library-view__header">
         <div>
-          <h1>Exercise Library</h1>
+          <h1>Library</h1>
           <p className="library-view__subtitle">
-            Search, tune form notes, and attach reference videos before the next session.
+            {tab === 'exercises'
+              ? 'Search, tune form notes, and attach reference videos before the next session.'
+              : 'Reusable workouts you can drop onto any day in the planner.'}
           </p>
         </div>
-        <div className="library-view__metric" aria-label={`${exercises.length} exercises`}>
-          <span>{exercises.length}</span>
-          <small>exercises</small>
+        <div
+          className="library-view__metric"
+          aria-label={tab === 'exercises' ? `${exercises.length} exercises` : `${templateList.length} templates`}
+        >
+          <span>{tab === 'exercises' ? exercises.length : templateList.length}</span>
+          <small>{tab === 'exercises' ? 'exercises' : 'templates'}</small>
         </div>
       </div>
 
+      <div className="library-view__tabs" role="tablist" aria-label="Library sections">
+        <button
+          role="tab"
+          aria-selected={tab === 'exercises'}
+          className={`library-view__tab ${tab === 'exercises' ? 'library-view__tab--active' : ''}`}
+          onClick={() => setTab('exercises')}
+        >
+          <BookOpen size={15} />
+          Exercises
+        </button>
+        <button
+          role="tab"
+          aria-selected={tab === 'templates'}
+          className={`library-view__tab ${tab === 'templates' ? 'library-view__tab--active' : ''}`}
+          onClick={() => setTab('templates')}
+        >
+          <Layers3 size={15} />
+          Templates
+        </button>
+      </div>
+
+      {tab === 'templates' ? (
+        <TemplateListView
+          templateList={templateList}
+          deleteTemplate={deleteTemplate}
+          navigate={navigate}
+          embedded
+        />
+      ) : !hasWorkouts ? (
+        <div className="empty-state">
+          <div className="empty-state-icon"><BookOpen size={48} /></div>
+          <h3>No exercises yet</h3>
+          <p className="text-secondary">Import a workout to populate your library</p>
+        </div>
+      ) : (
+        <>
       <div className="library-view__search-bar">
         <Search size={16} className="library-view__search-icon" />
         <input
@@ -554,6 +580,8 @@ export default function LibraryView({ workouts, youtubeLinks, setYouTubeLink, se
           </div>
         )}
       </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/views/LibraryView.tabs.test.jsx
+++ b/src/views/LibraryView.tabs.test.jsx
@@ -31,6 +31,7 @@ function renderLibrary(overrides = {}) {
     templateList,
     deleteTemplate: vi.fn(),
     navigate: vi.fn(),
+    onTabChange: vi.fn(),
     ...overrides,
   };
   return { ...render(<LibraryView {...props} />), props };
@@ -73,5 +74,13 @@ describe('LibraryView tabs', () => {
   it('shows the Templates tab even when there are no workouts/exercises', () => {
     renderLibrary({ workouts: {}, initialTab: 'templates' });
     expect(screen.getByText('Push Day')).toBeTruthy();
+  });
+
+  it('notifies onTabChange so the active tab can be persisted to route history', () => {
+    const { props } = renderLibrary();
+    fireEvent.click(screen.getByRole('tab', { name: /templates/i }));
+    expect(props.onTabChange).toHaveBeenCalledWith('templates');
+    fireEvent.click(screen.getByRole('tab', { name: /exercises/i }));
+    expect(props.onTabChange).toHaveBeenCalledWith('exercises');
   });
 });

--- a/src/views/LibraryView.tabs.test.jsx
+++ b/src/views/LibraryView.tabs.test.jsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import LibraryView from './LibraryView.jsx';
+
+const workouts = {
+  'Upper A': {
+    blocks: [
+      {
+        exercises: [
+          { title: 'Bench Press', notes: '', sets: [{ reps: 5, weight: 135, unit: 'lb' }] },
+        ],
+      },
+    ],
+  },
+};
+
+const templateList = [
+  { id: 'tpl_1', name: 'Push Day', blocks: [{ exercises: [{ title: 'Bench Press', sets: [] }] }] },
+  { id: 'tpl_2', name: 'Pull Day', blocks: [{ exercises: [{ title: 'Row', sets: [] }] }] },
+];
+
+function renderLibrary(overrides = {}) {
+  const props = {
+    workouts,
+    youtubeLinks: {},
+    setYouTubeLink: vi.fn(),
+    setManyYouTubeLinks: vi.fn(),
+    onExerciseTap: vi.fn(),
+    onUpdateExerciseNotes: vi.fn(),
+    templateList,
+    deleteTemplate: vi.fn(),
+    navigate: vi.fn(),
+    ...overrides,
+  };
+  return { ...render(<LibraryView {...props} />), props };
+}
+
+describe('LibraryView tabs', () => {
+  it('renders both Exercises and Templates tabs', () => {
+    renderLibrary();
+    expect(screen.getByRole('tab', { name: /exercises/i })).toBeTruthy();
+    expect(screen.getByRole('tab', { name: /templates/i })).toBeTruthy();
+  });
+
+  it('defaults to the Exercises tab', () => {
+    renderLibrary();
+    expect(screen.getByRole('tab', { name: /exercises/i }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByText('Bench Press')).toBeTruthy();
+    // Template names should not be visible on the exercises tab
+    expect(screen.queryByText('Push Day')).toBeNull();
+  });
+
+  it('switches to the Templates tab and shows template names', () => {
+    renderLibrary();
+    fireEvent.click(screen.getByRole('tab', { name: /templates/i }));
+    expect(screen.getByText('Push Day')).toBeTruthy();
+    expect(screen.getByText('Pull Day')).toBeTruthy();
+  });
+
+  it('honors initialTab="templates"', () => {
+    renderLibrary({ initialTab: 'templates' });
+    expect(screen.getByRole('tab', { name: /templates/i }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByText('Push Day')).toBeTruthy();
+  });
+
+  it('navigates to edit a template when a template row is tapped', () => {
+    const { props } = renderLibrary({ initialTab: 'templates' });
+    fireEvent.click(screen.getByText('Push Day'));
+    expect(props.navigate).toHaveBeenCalledWith('editTemplate', { templateId: 'tpl_1' });
+  });
+
+  it('shows the Templates tab even when there are no workouts/exercises', () => {
+    renderLibrary({ workouts: {}, initialTab: 'templates' });
+    expect(screen.getByText('Push Day')).toBeTruthy();
+  });
+});

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -14,13 +14,11 @@ import {
   AlertTriangle,
   Bell,
   CalendarDays,
-  ChevronRight,
   Cloud,
   Database,
   Download,
   FolderOpen,
   HardDrive,
-  Layers3,
   MessageSquare,
   ShieldAlert,
   Timer,
@@ -39,7 +37,6 @@ import {
   LS_WORKOUT_LOGS,
   LS_ACTIVE_SESSION,
   LS_TEMPLATES,
-  ROUTE_TEMPLATES,
 } from '../constants';
 
 export default function SettingsView({
@@ -48,7 +45,6 @@ export default function SettingsView({
   deleteTemplate,
   renameTemplate,
   duplicateTemplate,
-  navigate,
   onClearAllData,
   syncStatus,
   lastSynced,
@@ -304,19 +300,6 @@ export default function SettingsView({
               ))}
             </div>
           </div>
-          <button
-            className="settings-nav-row"
-            onClick={() => navigate(ROUTE_TEMPLATES)}
-          >
-            <span className="settings-nav-row__icon" aria-hidden="true"><Layers3 size={18} /></span>
-            <span className="settings-nav-row__body">
-              <strong>Templates</strong>
-              <small>
-                {templateList ? templateList.length : 0} template{(!templateList || templateList.length !== 1) ? 's' : ''} ready for planning
-              </small>
-            </span>
-            <ChevronRight size={18} className="settings-nav-row__chevron" />
-          </button>
         </section>
 
         <section className="settings-section">

--- a/src/views/TemplateListView.jsx
+++ b/src/views/TemplateListView.jsx
@@ -66,6 +66,7 @@ export default function TemplateListView({
   templateList,
   deleteTemplate,
   navigate,
+  embedded = false,
 }) {
   const [search, setSearch] = useState('');
   const [deleteTarget, setDeleteTarget] = useState(null);
@@ -85,26 +86,8 @@ export default function TemplateListView({
     }
   };
 
-  return (
-    <div className="view tpl-list-view">
-      <div className="tpl-list__header">
-        <button
-          className="tpl-list__back"
-          onClick={() => navigate(ROUTE_SETTINGS)}
-          aria-label="Back to settings"
-        >
-          <ArrowLeft size={20} />
-        </button>
-        <div className="tpl-list__heading">
-          <h1 className="tpl-list__title">Templates</h1>
-          <p>Reusable workouts for planning the week.</p>
-        </div>
-        <span className="tpl-list__count">
-          <Layers3 size={14} />
-          {templateList?.length || 0}
-        </span>
-      </div>
-
+  const body = (
+    <>
       {templateList && templateList.length > 5 && (
         <div className="tpl-list__search">
           <Search size={16} className="tpl-list__search-icon" />
@@ -170,6 +153,31 @@ export default function TemplateListView({
           </div>
         </div>
       )}
+    </>
+  );
+
+  if (embedded) return body;
+
+  return (
+    <div className="view tpl-list-view">
+      <div className="tpl-list__header">
+        <button
+          className="tpl-list__back"
+          onClick={() => navigate(ROUTE_SETTINGS)}
+          aria-label="Back to settings"
+        >
+          <ArrowLeft size={20} />
+        </button>
+        <div className="tpl-list__heading">
+          <h1 className="tpl-list__title">Templates</h1>
+          <p>Reusable workouts for planning the week.</p>
+        </div>
+        <span className="tpl-list__count">
+          <Layers3 size={14} />
+          {templateList?.length || 0}
+        </span>
+      </div>
+      {body}
     </div>
   );
 }


### PR DESCRIPTION
## What & why

Templates lived under Settings, disconnected from the Exercise Library where the rest of the reusable training content is managed. This moves them into the **Library** as a second tab alongside **Exercises**, so the Library is the single home for both.

## Changes

- **Library gets a segmented tab control** (`Exercises | Templates`). Header renamed to **Library**; subtitle + count metric adapt per tab.
- **Templates tab** reuses the existing `TemplateListView` via a new `embedded` prop (drops its standalone header/back button). Full swipe-to-delete, delete-confirm, search (>5), and tap-to-edit preserved.
- **Templates now live only in the Library** — removed the standalone `ROUTE_TEMPLATES` route/case and the Settings shortcut (plus now-dead imports and the constant).
- **Template editor** save/cancel return to the Library's Templates tab via `navigate(ROUTE_LIBRARY, { tab: 'templates' })`. Deep-linkable via `params.tab`.
- **Browser Back fix:** the active tab is persisted into the current history entry (`replaceState`) so returning from the editor via browser Back restores Templates instead of falling back to Exercises. (Caught in dual review.)

## Testing

- New `LibraryView.tabs.test.jsx` (7 tests, TDD) — tab rendering, default/initial tab, switching, edit navigation, no-workouts case, and the `onTabChange` route-persistence contract.
- Full suite: **423 passing**. Production build succeeds.
- Verified end-to-end in the browser incl. the browser-Back flow.

## Review

Ran dual-model review (GPT-5.5 code quality + Opus 4.8 security): security clean; one Low-severity Back-button finding, which is fixed in this PR.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>