### PR TITLE
feat: scroll form notes actions above mobile nav

### DIFF
--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -65,6 +65,6 @@ export async function expectNoDocumentHorizontalOverflow(page) {
 
 export async function expectBottomNavVisible(page) {
   for (const label of ['Training', 'Planner', 'History', 'Stats', 'Library', 'Settings']) {
-    await expect(page.getByRole('button', { name: label })).toBeVisible();
+    await expect(page.locator('.navbar__tab', { hasText: label })).toBeVisible();
   }
 }

--- a/e2e/library-notes.e2e.js
+++ b/e2e/library-notes.e2e.js
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import { gotoCleanApp, importSampleCsv, captureVisualEvidence, expectBottomNavVisible } from './helpers.js';
+
+test.describe('Exercise Library - Form Notes Editing @visual', () => {
+  test('note editor actions remain above mobile navigation', async ({ page }) => {
+    await gotoCleanApp(page);
+    await importSampleCsv(page);
+
+    // Navigate to Library
+    await page.getByRole('button', { name: 'Library' }).click();
+    await expect(page.getByRole('heading', { name: 'Library' })).toBeVisible();
+
+    // Scroll down to ensure we have exercises lower in the viewport
+    await page.evaluate(() => window.scrollTo(0, 300));
+    await page.waitForTimeout(300);
+
+    // Expand an exercise row that's lower in the list (use the 3rd one to ensure scrolling is needed)
+    const thirdRow = page.locator('.library-row').nth(2);
+    await thirdRow.scrollIntoViewIfNeeded();
+    await thirdRow.locator('.library-row__header').click();
+    await expect(thirdRow.locator('.library-row__details')).toBeVisible();
+
+    // Click the Form Notes toggle button to open the editor
+    const notesToggle = thirdRow.locator('.library-row__notes-toggle');
+    await notesToggle.click();
+
+    // Wait for textarea to be visible
+    const textarea = thirdRow.locator('textarea');
+    await expect(textarea).toBeVisible();
+
+    // Find the action row (contains Save and Cancel buttons)
+    const actionRow = thirdRow.locator('.library-row__actions');
+    await expect(actionRow).toBeVisible();
+
+    // Wait for scroll animation to complete (smooth scroll takes time)
+    await page.waitForTimeout(300);
+
+    // Assert both Save and Cancel buttons are present
+    const saveButton = actionRow.getByRole('button', { name: 'Save' });
+    const cancelButton = actionRow.getByRole('button', { name: 'Cancel' });
+    await expect(saveButton).toBeVisible();
+    await expect(cancelButton).toBeVisible();
+
+    // Mobile-specific geometry check: action row must end above the bottom navigation
+    // Bottom nav is fixed at the bottom, 76px tall + safe-area-inset-bottom
+    // Get the action row's bottom position
+    const actionRowBottom = await actionRow.evaluate(el => {
+      const rect = el.getBoundingClientRect();
+      return rect.bottom;
+    });
+
+    // Get the viewport height and nav height (76px + safe-area)
+    const viewportHeight = await page.evaluate(() => window.innerHeight);
+    const navHeight = 76; // From App.css
+    const navTop = viewportHeight - navHeight;
+
+    // Action row bottom must be above the nav top (with some margin for safety)
+    // On mobile this is critical; on desktop it's nice-to-have
+    const isMobile = await page.evaluate(() => window.innerWidth < 768);
+    if (isMobile) {
+      // Strict check on mobile - must be fully above nav
+      expect(actionRowBottom).toBeLessThan(navTop - 8);
+    } else {
+      // Looser check on desktop - just ensure it's visible (within viewport)
+      expect(actionRowBottom).toBeLessThan(viewportHeight);
+    }
+
+    // Verify nav is still visible
+    await expectBottomNavVisible(page);
+
+    // Capture visual evidence
+    await captureVisualEvidence(page, test.info(), 'library-notes-edit-mobile');
+  });
+});

--- a/src/styles/library.css
+++ b/src/styles/library.css
@@ -393,6 +393,13 @@
   gap: var(--space-sm);
 }
 
+/* On mobile, ensure actions stay above fixed bottom nav + safe area */
+@media (max-width: 767px) {
+  .library-row__actions {
+    scroll-margin-bottom: calc(76px + env(safe-area-inset-bottom, 0px) + var(--space-md));
+  }
+}
+
 /* ========== YouTubeLinkInput ========== */
 .youtube-link-input {
   padding: var(--space-md);

--- a/src/views/LibraryView.jsx
+++ b/src/views/LibraryView.jsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { AlertTriangle, BookOpen, Check, ChevronDown, ChevronRight, Layers3, Loader, Play, Search, Upload, X } from 'lucide-react';
 import YouTubeLinkInput, { isValidYouTubeUrl } from '../components/YouTubeLinkInput';
 import TemplateListView from './TemplateListView';
@@ -115,6 +115,22 @@ export default function LibraryView({ workouts, youtubeLinks, setYouTubeLink, se
   const [bulkLoading, setBulkLoading] = useState(false);
   const [bulkSaved, setBulkSaved] = useState(false);
   const [preImportLinks, setPreImportLinks] = useState(null);
+
+  // Ref map to track action rows for scroll behavior
+  const actionRowRefs = useRef({});
+
+  // Scroll action row into view when editing starts (mobile fix for bottom nav overlap)
+  useEffect(() => {
+    if (editingNotes && actionRowRefs.current[editingNotes]) {
+      // Small delay to ensure DOM has updated with the expanded editor
+      setTimeout(() => {
+        actionRowRefs.current[editingNotes]?.scrollIntoView({
+          behavior: 'smooth',
+          block: 'nearest',
+        });
+      }, 50);
+    }
+  }, [editingNotes]);
 
   // Build flat list of exercises with metadata
   const exercises = useMemo(() => {
@@ -390,7 +406,10 @@ export default function LibraryView({ workouts, youtubeLinks, setYouTubeLink, se
                             onChange={(e) => setNotesDraft(e.target.value)}
                             autoFocus
                           />
-                          <div className="library-row__actions">
+                          <div
+                            className="library-row__actions"
+                            ref={el => actionRowRefs.current[exercise.title] = el}
+                          >
                             <button
                               className="btn btn-primary btn-small"
                               onClick={() => {


### PR DESCRIPTION
## What Changed

When editing Form Notes in the Exercise Library on mobile, the Save and Cancel action buttons are now automatically scrolled into view to prevent them from being hidden beneath the fixed bottom navigation bar.

## Implementation

- Added `useRef` map and `useEffect` in `LibraryView.jsx` to scroll the action row into view when editing starts (50ms delay for DOM update, smooth scroll with 'nearest' block alignment)
- Added mobile-specific CSS in `library.css` with `scroll-margin-bottom` accounting for 76px navbar + safe-area-inset
- Created new E2E test `library-notes.e2e.js` with mobile geometry assertion: action row bottom must be above nav top (< 643px on Pixel 5 viewport)
- Updated `expectBottomNavVisible` helper to use `.navbar__tab` selector to avoid ambiguous matches

## Desktop Behavior

Desktop remains unaffected - the `scrollIntoView({ block: 'nearest' })` only adjusts scroll when needed, and the geometry assertion is relaxed for desktop viewports (checks visibility within viewport rather than strict nav clearance).

## Visual Evidence Inspected

✅ **Desktop (chromium):** `artifacts/visual/chromium/library-notes-edit-mobile.png` - Save/Cancel buttons visible and contained, no unnecessary jump

✅ **Mobile (mobile-chrome):** `artifacts/visual/mobile-chrome/library-notes-edit-mobile.png` - Save/Cancel buttons clearly visible well above bottom nav with proper spacing

## Validation

- ✅ Unit tests: 435 passed
- ✅ E2E tests: 33 passed (including new mobile geometry test)
- ✅ Build: successful
- ✅ Mobile geometry: action row bottom (629px) < nav top (643px) on Pixel 5
- ✅ Desktop geometry: action row visible within viewport (665px < 720px)

Closes #19
