### PR TITLE
feat: add sticky Apply Plan button for unsaved planner changes

### DIFF
--- a/e2e/planner-flow.e2e.js
+++ b/e2e/planner-flow.e2e.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { gotoCleanApp, importSampleCsv } from './helpers';
+import { gotoCleanApp, importSampleCsv, captureVisualEvidence, expectBottomNavVisible } from './helpers';
 
 test('assigns a template from Planner and opens the scheduled workout', async ({ page }) => {
   await gotoCleanApp(page);
@@ -17,4 +17,40 @@ test('assigns a template from Planner and opens the scheduled workout', async ({
   await page.getByRole('button', { name: 'Pull Day' }).click();
   await expect(page.getByRole('heading', { name: 'Pull Day' })).toBeVisible();
   await expect(page.getByRole('button', { name: 'Start Workout' })).toBeVisible();
+});
+
+test('@visual sticky Apply Plan appears for unsaved changes and disappears after apply', async ({ page }, testInfo) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+
+  await page.getByRole('button', { name: 'Planner' }).click();
+  
+  // Before making changes, Apply Plan should not be visible
+  const applyButton = page.getByRole('button', { name: 'Apply Plan' });
+  await expect(applyButton).not.toBeVisible();
+
+  // Assign a template to Monday
+  await page.getByRole('button', { name: '+ Add' }).first().click();
+  await expect(page.getByRole('heading', { name: 'Pick a Template' })).toBeVisible();
+  await page.getByRole('button', { name: /Pull Day\s+4 exercises/ }).click();
+
+  // Apply Plan should now be visible in the viewport without scrolling
+  await expect(page.getByText('Unsaved changes')).toBeVisible();
+  await expect(applyButton).toBeInViewport();
+  
+  // Capture evidence showing sticky Apply Plan with unsaved badge
+  await captureVisualEvidence(page, testInfo, 'planner-sticky-apply-visible');
+
+  // Bottom nav should remain visible (not covered by sticky action)
+  await expectBottomNavVisible(page);
+
+  // Apply the plan
+  await applyButton.click();
+
+  // Sticky Apply Plan should disappear
+  await expect(applyButton).not.toBeVisible();
+  await expect(page.getByText('Unsaved changes')).not.toBeVisible();
+
+  // Capture evidence showing no sticky action after apply
+  await captureVisualEvidence(page, testInfo, 'planner-sticky-apply-hidden');
 });

--- a/src/styles/planner.css
+++ b/src/styles/planner.css
@@ -205,9 +205,11 @@
 .planner-view__sticky-action {
   position: fixed;
   right: 0;
-  bottom: calc(var(--navbar-height) + var(--space-md));
+  bottom: calc(76px + var(--space-md));
   left: 0;
-  z-index: 10;
+  z-index: var(--z-sticky);
+  max-width: var(--app-max-width);
+  margin-inline: auto;
   padding: 0 var(--space-lg);
   pointer-events: none;
 }

--- a/src/styles/planner.css
+++ b/src/styles/planner.css
@@ -201,6 +201,25 @@
   min-width: 88px;
 }
 
+/* Sticky Apply Plan */
+.planner-view__sticky-action {
+  position: fixed;
+  right: 0;
+  bottom: calc(var(--navbar-height) + var(--space-md));
+  left: 0;
+  z-index: 10;
+  padding: 0 var(--space-lg);
+  pointer-events: none;
+}
+
+.planner-view__sticky-action .btn {
+  width: 100%;
+  min-height: 54px;
+  border-radius: var(--radius-lg);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.3);
+  pointer-events: auto;
+}
+
 .planner-view__actions {
   display: flex;
   flex-direction: column;
@@ -385,6 +404,10 @@
   .planner-view__nav,
   .planner-view__grid,
   .planner-view__actions {
+    padding-inline: var(--space-md);
+  }
+
+  .planner-view__sticky-action {
     padding-inline: var(--space-md);
   }
 

--- a/src/views/WeekPlannerView.jsx
+++ b/src/views/WeekPlannerView.jsx
@@ -283,12 +283,16 @@ export default function WeekPlannerView({
         })}
       </div>
 
-      <div className="planner-view__actions">
-        {hasDraftChanges && (
+      {/* Sticky Apply Plan (visible when unsaved changes exist) */}
+      {hasDraftChanges && (
+        <div className="planner-view__sticky-action">
           <button className="btn btn-primary w-full" onClick={applyPlan}>
             Apply Plan
           </button>
-        )}
+        </div>
+      )}
+
+      <div className="planner-view__actions">
         <div className="planner-view__secondary-actions">
           <button
             className="btn btn-secondary btn-small"


### PR DESCRIPTION
# Sticky Apply Plan Button for Unsaved Planner Changes

Closes #21

## Summary

When the weekly plan has unsaved changes, Apply Plan now appears as a sticky action above the bottom navigation, allowing users to commit drafts without scrolling past all seven days. The existing unsaved badge and secondary actions remain unchanged.

## Changes

- **WeekPlannerView.jsx**: Add sticky container that renders Apply Plan button when `hasDraftChanges` is true, remove it from the bottom actions section
- **planner.css**: Add `.planner-view__sticky-action` with fixed positioning above bottom nav, constrained to app column width, proper z-index, box shadow for depth, and responsive padding
- **planner-flow.e2e.js**: Add `@visual` test that verifies sticky Apply Plan visibility before scrolling and disappearance after apply

## Visual Evidence

Desktop and mobile screenshots inspected after code review fix:
- `artifacts/visual/chromium/planner-sticky-apply-visible.png`
- `artifacts/visual/chromium/planner-sticky-apply-hidden.png`
- `artifacts/visual/mobile-chrome/planner-sticky-apply-visible.png`
- `artifacts/visual/mobile-chrome/planner-sticky-apply-hidden.png`

✅ Apply Plan is visible in viewport without scrolling after assigning a template  
✅ Sticky action is constrained to 480px app column on desktop (not full-width)
✅ Button positioned above bottom nav with 76px + 12px spacing
✅ Uses semantic `--z-sticky` z-index (100) instead of hardcoded value
✅ Doesn't overlap day cards, secondary actions, feedback FAB, or bottom nav  
✅ Button disappears after applying the plan  
✅ Unsaved badge remains visible in header  
✅ Stay/Discard navigation protection still works

## Code Review Notes

**Dual-model review (GPT-5.5 quality + Claude Opus 4.8 security):**

**GPT-5.5 finding (adopted):** Initial implementation used undefined `--navbar-height` CSS variable, causing sticky action to render at viewport top with full browser width instead of above bottom nav within the app column. Fixed by:
- Replacing `var(--navbar-height)` with explicit `76px` (measured navbar height)
- Adding `max-width: var(--app-max-width)` and `margin-inline: auto` to constrain to 480px app column
- Using semantic `--z-sticky` variable instead of hardcoded `z-index: 10`

**Claude Opus 4.8:** No security issues found. Purely presentational change with no new input handling, rendering of user data, network requests, or auth logic.

## Testing

- ✅ Unit tests: 435 passed
- ✅ E2E tests: 41 passed (including new planner sticky test on both viewports)
- ✅ Build: successful
- ✅ Visual evidence re-verified after code review fix
