### PR TITLE
fix: align Settings section headings with card content

### DIFF
--- a/e2e/settings-visual.e2e.js
+++ b/e2e/settings-visual.e2e.js
@@ -142,4 +142,55 @@ test.describe('Settings visual states @visual', () => {
     // Capture focused state
     await captureVisualEvidence(page, testInfo, 'checkbox-focused');
   });
+  
+  test('Section headings align with card content', async ({ page }, testInfo) => {
+    await gotoCleanApp(page);
+    await importSampleCsv(page);
+    
+    // Navigate to Settings
+    await page.getByRole('button', { name: 'Settings' }).click();
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    
+    // Find all settings sections
+    const sections = page.locator('.settings-section');
+    const sectionCount = await sections.count();
+    
+    // Test each section
+    for (let i = 0; i < sectionCount; i++) {
+      const section = sections.nth(i);
+      
+      // Get the section heading (h2 within settings-section__head)
+      const heading = section.locator('.settings-section__head h2');
+      if (await heading.count() === 0) continue;
+      
+      // Get the first content element after the heading
+      // This could be a .settings-control, .settings-view__reminder-row, or other content div
+      const contentElements = section.locator('.settings-control, .settings-view__reminder-row, .settings-view__sync-status, .settings-subsection, .settings-view__storage');
+      if (await contentElements.count() === 0) continue;
+      
+      const firstContent = contentElements.first();
+      
+      // Get bounding boxes
+      const headingBox = await heading.boundingBox();
+      const contentBox = await firstContent.boundingBox();
+      const sectionBox = await section.boundingBox();
+      
+      if (!headingBox || !contentBox || !sectionBox) continue;
+      
+      // The heading's left edge should align with the content's left edge
+      // (both should be inset from the section's left edge by the same amount)
+      const headingLeftInset = headingBox.x - sectionBox.x;
+      const contentLeftInset = contentBox.x - sectionBox.x;
+      
+      // Allow 1px tolerance for rounding
+      expect(Math.abs(headingLeftInset - contentLeftInset)).toBeLessThanOrEqual(1);
+      
+      // Also verify heading doesn't touch the section border (should have some inset)
+      // Settings section has 1px border + should have padding
+      expect(headingLeftInset).toBeGreaterThan(5); // At minimum, some padding
+    }
+    
+    // Capture desktop evidence
+    await captureVisualEvidence(page, testInfo, 'settings-heading-alignment');
+  });
 });

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -95,10 +95,20 @@
   line-height: 1.15;
 }
 
-.settings-section__head p,
+.settings-section__head p {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  text-wrap: pretty;
+}
+
 .settings-section__message,
 .settings-section__hint {
-  margin: 0;
+  /* Indent to align with heading text */
+  margin-left: calc(42px + var(--space-md));
+  margin-top: 0;
+  margin-bottom: 0;
   color: var(--text-secondary);
   font-size: var(--text-sm);
   line-height: 1.45;
@@ -114,7 +124,10 @@
   display: flex;
   align-items: flex-start;
   gap: var(--space-xs);
-  margin: 0;
+  /* Indent to align with heading text */
+  margin-left: calc(42px + var(--space-md));
+  margin-top: 0;
+  margin-bottom: 0;
   color: var(--warning);
   font-size: var(--text-sm);
   font-weight: 650;
@@ -129,6 +142,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
+  /* Indent to align with heading text (icon 42px + gap 12px) */
+  margin-left: calc(42px + var(--space-md));
   padding: var(--space-md);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
@@ -228,6 +243,8 @@
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--space-md);
+  /* Indent to align with heading text */
+  margin-left: calc(42px + var(--space-md));
   min-height: 52px;
   padding: var(--space-md);
   border: 1px solid var(--border-subtle);
@@ -252,12 +269,16 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--space-sm);
+  /* Indent to align with heading text */
+  margin-left: calc(42px + var(--space-md));
 }
 
 .settings-view__sync-status {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
+  /* Indent to align with heading text */
+  margin-left: calc(42px + var(--space-md));
   min-height: 48px;
   padding: var(--space-md);
   border: 1px solid var(--border-subtle);
@@ -300,6 +321,8 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-sm);
+  /* Indent to align with heading text */
+  margin-left: calc(42px + var(--space-md));
 }
 
 .settings-view__data-actions .btn {
@@ -308,6 +331,8 @@
 }
 
 .settings-subsection {
+  /* Indent to align with heading text */
+  margin-left: calc(42px + var(--space-md));
   padding-top: var(--space-xs);
 }
 
@@ -324,6 +349,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-sm);
+  /* Indent to align with heading text */
+  margin-left: calc(42px + var(--space-md));
 }
 
 .settings-view__storage-top {
@@ -369,6 +396,12 @@
   font-size: var(--text-sm);
   font-weight: 700;
   text-align: center;
+}
+
+/* Indent direct-child buttons and version text to align with heading text */
+.settings-section > .btn,
+.settings-section > button {
+  margin-left: calc(42px + var(--space-md));
 }
 
 .settings-clear-modal__message {


### PR DESCRIPTION
# Align Settings section headings with card content

Closes #22

## Changes

- Indent all content elements (`.settings-control`, `.settings-section__message`, `.settings-view__sync-status`, `.settings-view__data-actions`, `.settings-subsection`, `.settings-view__storage`, and direct-child buttons) with `margin-left: calc(42px + var(--space-md))`
- Heading text now aligns horizontally with card content elements
- Icons stay fully visible within section borders (no clipping)
- Verified alignment at both desktop and mobile widths with Playwright geometry assertions

## Visual Evidence Inspected

**Desktop (chromium):**
- ✅ `artifacts/visual/chromium/settings-heading-alignment.png`
- All section headings align perfectly with their content
- Icons (timer, bell, cloud, etc.) are fully visible - no clipping
- Content properly indented to align with heading text, not icon

**Mobile (mobile-chrome):**
- ✅ `artifacts/visual/mobile-chrome/settings-heading-alignment.png`
- Same perfect alignment maintained at mobile width
- Icons fully visible with no clipping
- No horizontal overflow

## Testing

- ✅ New E2E test: `Section headings align with card content` (desktop + mobile)
- ✅ All unit tests pass (435 tests)
- ✅ All E2E tests pass (43 tests)
- ✅ Production build succeeds

## Review Notes

**Dual code review findings:**

**Security (claude-opus-4.8):** No security issues found - CSS-only cosmetic change.

**Code Quality (gpt-5.5):** Initial approach clipped icons by using negative margin on the header container. **Fixed** by removing negative margin and instead indenting content elements to align with heading text while keeping icons within section borders. This resolves the icon clipping issue while maintaining the desired heading-to-content alignment.

Applied TDD workflow (red-green-refactor):
1. **Red**: Added failing test checking heading vs. content left inset (initially 54px misaligned)
2. **Green**: Initially fixed with negative margin (caused icon clipping)
3. **Refactor**: Corrected to use content indentation instead (icons now fully visible)
4. **Verify**: Inspected desktop/mobile screenshots confirming proper alignment with no clipping
