### PR TITLE
fix: use auto-fit grid for backup actions to prevent narrow wrapping

### DIFF
--- a/e2e/settings-visual.e2e.js
+++ b/e2e/settings-visual.e2e.js
@@ -193,4 +193,65 @@ test.describe('Settings visual states @visual', () => {
     // Capture desktop evidence
     await captureVisualEvidence(page, testInfo, 'settings-heading-alignment');
   });
+
+  test('Backup actions stack on mobile without narrow wrapping', async ({ page }, testInfo) => {
+    await gotoCleanApp(page);
+    await importSampleCsv(page);
+    
+    // Navigate to Settings
+    await page.getByRole('button', { name: 'Settings' }).click();
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    
+    // Scroll to Data portability section
+    const dataSection = page.locator('.settings-section').filter({ has: page.getByRole('heading', { name: 'Data portability' }) });
+    await dataSection.scrollIntoViewIfNeeded();
+    
+    // Find the backup action buttons container (the one with Re-import, Export Backup, Restore)
+    const backupActionsContainer = dataSection.locator('.settings-view__data-actions').last();
+    const backupButtons = backupActionsContainer.locator('button');
+    
+    // Should have exactly 3 backup action buttons
+    await expect(backupButtons).toHaveCount(3);
+    
+    // Get button labels for verification
+    await expect(backupButtons.nth(0)).toContainText('Re-import CSV');
+    await expect(backupButtons.nth(1)).toContainText('Export Backup');
+    await expect(backupButtons.nth(2)).toContainText('Restore from Backup');
+    
+    // All three buttons should be at least 44px tall (WCAG touch target)
+    for (let i = 0; i < 3; i++) {
+      const box = await backupButtons.nth(i).boundingBox();
+      expect(box.height).toBeGreaterThanOrEqual(44);
+    }
+    
+    // Get viewport width to determine expected layout
+    const viewportWidth = page.viewportSize().width;
+    const box1 = await backupButtons.nth(0).boundingBox();
+    const box2 = await backupButtons.nth(1).boundingBox();
+    const box3 = await backupButtons.nth(2).boundingBox();
+    const containerBox = await backupActionsContainer.boundingBox();
+    
+    if (viewportWidth <= 430) {
+      // Mobile: buttons should be vertically stacked (no horizontal neighbors)
+      expect(box2.y).toBeGreaterThan(box1.y + box1.height - 1); // Button2 below button1
+      expect(box3.y).toBeGreaterThan(box2.y + box2.height - 1); // Button3 below button2
+      
+      // Each button should be nearly full-width on mobile (not squeezed into columns)
+      for (let i = 0; i < 3; i++) {
+        const buttonBox = await backupButtons.nth(i).boundingBox();
+        expect(buttonBox.width).toBeGreaterThan(containerBox.width * 0.85);
+      }
+    } else {
+      // Desktop: buttons can be multi-column, but not excessively narrow
+      // Allow for grid layouts (2-column or 3-column)
+      for (let i = 0; i < 3; i++) {
+        const buttonBox = await backupButtons.nth(i).boundingBox();
+        // Buttons shouldn't be squeezed below reasonable width (min ~140px for icon+text)
+        expect(buttonBox.width).toBeGreaterThanOrEqual(140);
+      }
+    }
+    
+    // Capture viewport-specific evidence
+    await captureVisualEvidence(page, testInfo, viewportWidth <= 430 ? 'backup-actions-mobile' : 'backup-actions-desktop');
+  });
 });

--- a/src/styles/settings.css
+++ b/src/styles/settings.css
@@ -319,7 +319,7 @@
 
 .settings-view__data-actions {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: var(--space-sm);
   /* Indent to align with heading text */
   margin-left: calc(42px + var(--space-md));


### PR DESCRIPTION
## Summary

Improves backup action button layout in Settings to prevent narrow wrapping on mobile and create a more balanced grid on desktop.

## Changes

- Changed `.settings-view__data-actions` from fixed `repeat(2, minmax(0, 1fr))` to `repeat(auto-fit, minmax(160px, 1fr))`
- Added visual regression test for backup actions in both desktop and mobile viewports
- Mobile (≤430px): buttons stack vertically via existing breakpoint
- Desktop: auto-fit distributes 3 buttons more evenly without forcing 2+1 narrow wrapping

## Visual Evidence

Inspected both viewports to verify layout and text wrapping:

**Mobile (Pixel 5, 393px):**
- `artifacts/visual/mobile-chrome/backup-actions-mobile.png`
- All 3 backup buttons stack vertically
- Each button full-width, labels fit on 2 lines without narrow wrapping
- All buttons meet 44px WCAG touch target

**Desktop (1280px):**
- `artifacts/visual/chromium/backup-actions-desktop.png`
- Balanced 2-column auto-fit layout
- Buttons maintain readable width (≥160px minimum)
- Icons and text remain clear and accessible

## Testing

- ✅ Unit tests: all 435 passed
- ✅ E2E tests: settings-visual.e2e.js (10/10 passed)
- ✅ Build: production bundle builds successfully
- ✅ Visual regression: captured and inspected desktop + mobile evidence

Closes #24
