### PR TITLE
feat: show empty state in planner template picker when search has no matches

### DIFF
--- a/e2e/planner-flow.e2e.js
+++ b/e2e/planner-flow.e2e.js
@@ -54,3 +54,43 @@ test('@visual sticky Apply Plan appears for unsaved changes and disappears after
   // Capture evidence showing no sticky action after apply
   await captureVisualEvidence(page, testInfo, 'planner-sticky-apply-hidden');
 });
+
+test('@visual template picker shows empty state for no search matches and allows recovery', async ({ page }, testInfo) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+
+  await page.getByRole('button', { name: 'Planner' }).click();
+  await page.getByRole('button', { name: '+ Add' }).first().click();
+  await expect(page.getByRole('heading', { name: 'Pick a Template' })).toBeVisible();
+
+  // Initially, template list should show templates
+  await expect(page.getByRole('button', { name: /Pull Day\s+4 exercises/ })).toBeVisible();
+
+  // Search for a non-existent template
+  const searchInput = page.getByPlaceholder('Search templates...');
+  await searchInput.fill('NonExistentWorkout');
+
+  // Empty state should appear with search query
+  await expect(page.getByText(/No templates match/)).toBeVisible();
+  await expect(page.getByText(/NonExistentWorkout/)).toBeVisible();
+  
+  // Template list items should not be visible
+  await expect(page.getByRole('button', { name: /Pull Day\s+4 exercises/ })).not.toBeVisible();
+
+  // Capture desktop empty state
+  await captureVisualEvidence(page, testInfo, 'planner-search-empty-state');
+
+  // Clear Search button should be visible
+  const clearSearchBtn = page.getByRole('button', { name: 'Clear Search' });
+  await expect(clearSearchBtn).toBeVisible();
+
+  // Click Clear Search
+  await clearSearchBtn.click();
+
+  // Search input should be cleared
+  await expect(searchInput).toHaveValue('');
+
+  // Template list should return
+  await expect(page.getByRole('button', { name: /Pull Day\s+4 exercises/ })).toBeVisible();
+  await expect(page.getByText('No templates match')).not.toBeVisible();
+});

--- a/src/views/WeekPlannerView.jsx
+++ b/src/views/WeekPlannerView.jsx
@@ -351,24 +351,44 @@ export default function WeekPlannerView({
                     onChange={(e) => setTemplateSearch(e.target.value)}
                   />
                 </label>
-                <div className="template-picker__list">
-                  {templateList
-                    .filter((tpl) =>
-                      tpl.name.toLowerCase().includes(templateSearch.toLowerCase())
-                    )
-                    .map((tpl) => (
-                      <button
-                        key={tpl.id}
-                        className="template-picker__item"
-                        onClick={() => assignTemplate(showPicker, tpl.id)}
-                      >
-                        <span className="template-picker__name">{tpl.name}</span>
-                        <span className="template-picker__meta">
-                          {tpl.blocks.reduce((sum, b) => sum + b.exercises.length, 0)} exercises
-                        </span>
-                      </button>
-                    ))}
-                </div>
+                {(() => {
+                  const filteredTemplates = templateList.filter((tpl) =>
+                    tpl.name.toLowerCase().includes(templateSearch.toLowerCase())
+                  );
+
+                  if (filteredTemplates.length === 0 && templateSearch) {
+                    return (
+                      <div className="empty-state">
+                        <p className="text-secondary">
+                          No templates match &ldquo;{templateSearch}&rdquo;
+                        </p>
+                        <button
+                          className="btn btn-secondary btn-small mt-md"
+                          onClick={() => setTemplateSearch('')}
+                        >
+                          Clear Search
+                        </button>
+                      </div>
+                    );
+                  }
+
+                  return (
+                    <div className="template-picker__list">
+                      {filteredTemplates.map((tpl) => (
+                        <button
+                          key={tpl.id}
+                          className="template-picker__item"
+                          onClick={() => assignTemplate(showPicker, tpl.id)}
+                        >
+                          <span className="template-picker__name">{tpl.name}</span>
+                          <span className="template-picker__meta">
+                            {tpl.blocks.reduce((sum, b) => sum + b.exercises.length, 0)} exercises
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  );
+                })()}
               </>
             )}
 


### PR DESCRIPTION
## Summary

Implements empty state handling in the Week Planner template picker when a search query returns no matches.

## Changes

- Added conditional rendering in `WeekPlannerView.jsx` to detect when filtered template list is empty
- Display message: "No templates match `<query>`" with the actual search term
- Added Clear Search button that resets the query and restores full template list
- E2E test in `planner-flow.e2e.js` verifies empty state appearance and recovery workflow

## Visual Evidence

Inspected screenshots confirm the implementation on both viewports:

**Desktop (`artifacts/visual/chromium/planner-search-empty-state.png`):**
- Empty state message clearly visible with search query
- Clear Search button properly positioned and styled
- No clipping or layout issues

**Mobile (`artifacts/visual/mobile-chrome/planner-search-empty-state.png`):**
- Same content readable on mobile viewport
- Clear Search button has adequate touch target
- Modal fits viewport without horizontal overflow
- Bottom nav remains visible

## Testing

- ✅ Unit tests: 435 passed
- ✅ E2E tests: 53 passed (including new template search test)
- ✅ Build: successful
- ✅ Visual verification: desktop and mobile screenshots inspected

## Review Notes

**Dual-model code review completed:**
- GPT-5.5 (code quality & correctness): No significant issues found
- Claude Opus 4.8 (security vulnerabilities): No significant issues found. React's automatic escaping prevents XSS in the displayed search query.

## Acceptance Criteria

- ✅ No-match search displays `No templates match "<query>"`
- ✅ Clear Search button resets query and restores template choices
- ✅ Empty state is readable and contained on desktop and mobile
- ✅ Planner E2E coverage exercises no results and recovery

Closes #26
