### PR TITLE
feat: add Go to Training action to empty template list

### DIFF
--- a/e2e/templates.e2e.js
+++ b/e2e/templates.e2e.js
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { gotoCleanApp, importSampleCsv, captureVisualEvidence } from './helpers';
 
-test('@visual empty template list shows next action and navigates to Training', async ({ page }, testInfo) => {
+test('@visual empty template list shows next action and navigates to Import', async ({ page }, testInfo) => {
   await gotoCleanApp(page);
 
   // Navigate to Library → Templates (with zero templates)
@@ -15,18 +15,18 @@ test('@visual empty template list shows next action and navigates to Training', 
   const explanation = page.getByText(/created from imported workouts/i);
   await expect(explanation).toBeVisible();
 
-  // Should have a "Go to Training" action
-  const goToTrainingBtn = page.getByRole('button', { name: /Go to Training/i });
-  await expect(goToTrainingBtn).toBeVisible();
+  // Should have an "Import Workout" action
+  const importBtn = page.getByRole('button', { name: /Import Workout/i });
+  await expect(importBtn).toBeVisible();
 
   // Capture visual evidence of empty state with action
   await captureVisualEvidence(page, testInfo, 'templates-empty-with-action');
 
-  // Click the action and verify navigation to Training view
-  await goToTrainingBtn.click();
+  // Click the action and verify navigation to Import view
+  await importBtn.click();
 
-  // Should land on Training view - verify by looking for Training-specific UI
-  await expect(page.getByRole('heading', { name: /Good (morning|afternoon|evening)/ })).toBeVisible();
+  // Should land on Import view - verify by looking for Import heading
+  await expect(page.getByRole('heading', { name: 'Import TrainHeroic CSV' })).toBeVisible();
 });
 
 test('populated template list retains current behavior', async ({ page }) => {
@@ -43,6 +43,6 @@ test('populated template list retains current behavior', async ({ page }) => {
   // Should show template rows
   await expect(page.getByRole('button', { name: /Lower Body B/ })).toBeVisible();
   
-  // Should NOT show "Go to Training" button when templates exist
-  await expect(page.getByRole('button', { name: /Go to Training/i })).not.toBeVisible();
+  // Should NOT show "Import Workout" button when templates exist
+  await expect(page.getByRole('button', { name: /Import Workout/i })).not.toBeVisible();
 });

--- a/e2e/templates.e2e.js
+++ b/e2e/templates.e2e.js
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+import { gotoCleanApp, importSampleCsv, captureVisualEvidence } from './helpers';
+
+test('@visual empty template list shows next action and navigates to Training', async ({ page }, testInfo) => {
+  await gotoCleanApp(page);
+
+  // Navigate to Library → Templates (with zero templates)
+  await page.getByRole('button', { name: 'Library' }).click();
+  await page.getByRole('tab', { name: 'Templates' }).click();
+
+  // Empty state should be visible
+  await expect(page.getByRole('heading', { name: 'No templates yet', level: 2 })).toBeVisible();
+
+  // Should explain how templates are created
+  const explanation = page.getByText(/created from imported workouts/i);
+  await expect(explanation).toBeVisible();
+
+  // Should have a "Go to Training" action
+  const goToTrainingBtn = page.getByRole('button', { name: /Go to Training/i });
+  await expect(goToTrainingBtn).toBeVisible();
+
+  // Capture visual evidence of empty state with action
+  await captureVisualEvidence(page, testInfo, 'templates-empty-with-action');
+
+  // Click the action and verify navigation to Training view
+  await goToTrainingBtn.click();
+
+  // Should land on Training view - verify by looking for Training-specific UI
+  await expect(page.getByRole('heading', { name: /Good (morning|afternoon|evening)/ })).toBeVisible();
+});
+
+test('populated template list retains current behavior', async ({ page }) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+
+  // Navigate to Library → Templates (now with templates)
+  await page.getByRole('button', { name: 'Library' }).click();
+  await page.getByRole('tab', { name: 'Templates' }).click();
+
+  // Should NOT show the empty state
+  await expect(page.getByRole('heading', { name: 'No templates yet', level: 2 })).not.toBeVisible();
+
+  // Should show template rows
+  await expect(page.getByRole('button', { name: /Lower Body B/ })).toBeVisible();
+  
+  // Should NOT show "Go to Training" button when templates exist
+  await expect(page.getByRole('button', { name: /Go to Training/i })).not.toBeVisible();
+});

--- a/src/views/TemplateListView.jsx
+++ b/src/views/TemplateListView.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
 import { ArrowLeft, ChevronRight, Layers3, Search, Trash2 } from 'lucide-react';
-import { ROUTE_SETTINGS, ROUTE_EDIT_TEMPLATE } from '../constants';
+import { ROUTE_SETTINGS, ROUTE_EDIT_TEMPLATE, ROUTE_TRAINING } from '../constants';
 
 const SWIPE_THRESHOLD = 80;
 
@@ -106,7 +106,20 @@ export default function TemplateListView({
           <div className="tpl-list__empty">
             <span className="tpl-list__empty-icon" aria-hidden="true"><Layers3 size={30} /></span>
             <h2>{search ? 'No matching templates' : 'No templates yet'}</h2>
-            <p>{search ? 'Try a shorter search term.' : 'Imported workouts become templates you can reuse in the planner.'}</p>
+            <p>
+              {search
+                ? 'Try a shorter search term.'
+                : 'Templates are created from imported workouts. Import a workout in Training to get started.'}
+            </p>
+            {!search && (
+              <button
+                className="btn btn-primary"
+                onClick={() => navigate(ROUTE_TRAINING)}
+                style={{ marginTop: '1rem' }}
+              >
+                Go to Training
+              </button>
+            )}
           </div>
         ) : (
           filtered.map((tpl) => {

--- a/src/views/TemplateListView.jsx
+++ b/src/views/TemplateListView.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef } from 'react';
 import { ArrowLeft, ChevronRight, Layers3, Search, Trash2 } from 'lucide-react';
-import { ROUTE_SETTINGS, ROUTE_EDIT_TEMPLATE, ROUTE_TRAINING } from '../constants';
+import { ROUTE_SETTINGS, ROUTE_EDIT_TEMPLATE, ROUTE_IMPORT } from '../constants';
 
 const SWIPE_THRESHOLD = 80;
 
@@ -109,15 +109,15 @@ export default function TemplateListView({
             <p>
               {search
                 ? 'Try a shorter search term.'
-                : 'Templates are created from imported workouts. Import a workout in Training to get started.'}
+                : 'Templates are created from imported workouts. Import a workout to get started.'}
             </p>
             {!search && (
               <button
                 className="btn btn-primary"
-                onClick={() => navigate(ROUTE_TRAINING)}
+                onClick={() => navigate(ROUTE_IMPORT)}
                 style={{ marginTop: '1rem' }}
               >
-                Go to Training
+                Import Workout
               </button>
             )}
           </div>


### PR DESCRIPTION
Closes #28

## What changed

Turned the empty Templates view into a useful starting point by adding:
- Clear explanation that templates are created from imported workouts
- "Import Workout" button that navigates directly to Import view
- E2E test coverage for empty state navigation and populated list behavior

## Visual evidence

Desktop:
- `artifacts/visual/chromium/templates-empty-with-action.png`

Mobile:
- `artifacts/visual/mobile-chrome/templates-empty-with-action.png`

Both viewports show:
- Centered, readable empty state with helpful explanation
- Primary blue "Import Workout" button is tappable and visible
- No clipping or overflow
- Button positioned above bottom navigation on mobile
- Consistent dark theme styling

## Validation

All local checks pass:
- ✅ `npm run test:unit` (435 tests)
- ✅ `npm run test:e2e` (61 tests)
- ✅ `npm run build`
- ✅ Visual evidence captured and inspected

## Review notes

**Dual-model code review findings:**

- **GPT-5.5 (quality):** Identified that initial "Go to Training" CTA would create a dead end for zero-template/zero-workout users, since Training hides Quick Start when `templateList.length === 0`. Fixed by routing to ROUTE_IMPORT instead, ensuring users land at the CSV import flow.
- **Claude Opus 4.8 (security):** No security issues found — purely presentational change with static strings and existing routing.

## Decisions

- Button routes to Import, not Training, to avoid dead-end UX for new users
- Button only shows in true-empty state, not search-no-match state (search already has recovery guidance)
- Used inline style for button margin-top to avoid adding a new CSS class for one element
