### PR TITLE
fix: initialize resumed workout elapsed time immediately

### DIFF
--- a/src/components/SessionHeader.jsx
+++ b/src/components/SessionHeader.jsx
@@ -1,6 +1,26 @@
 import { useState, useEffect } from 'react';
 import { X, Timer, Pencil } from 'lucide-react';
 
+// Calculate elapsed time string from startedAt timestamp
+function calculateElapsed(startedAt) {
+  if (!startedAt || isNaN(new Date(startedAt).getTime())) {
+    return '0:00';
+  }
+  const now = new Date();
+  const start = new Date(startedAt);
+  const diff = Math.floor((now - start) / 1000); // seconds
+
+  const hours = Math.floor(diff / 3600);
+  const minutes = Math.floor((diff % 3600) / 60);
+  const seconds = diff % 60;
+
+  if (hours > 0) {
+    return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+  } else {
+    return `${minutes}:${String(seconds).padStart(2, '0')}`;
+  }
+}
+
 export default function SessionHeader({
   workoutTitle,
   startedAt,
@@ -9,31 +29,16 @@ export default function SessionHeader({
   isEditMode = false,
   onToggleEdit = null,
 }) {
-  const [elapsed, setElapsed] = useState('0:00');
+  // Initialize elapsed synchronously from startedAt
+  const [elapsed, setElapsed] = useState(() => calculateElapsed(startedAt));
 
   useEffect(() => {
+    // Update immediately in case startedAt changed
+    setElapsed(calculateElapsed(startedAt));
+
+    // Then update every second
     const interval = setInterval(() => {
-      if (!startedAt || isNaN(new Date(startedAt).getTime())) {
-        setElapsed('0:00');
-        return;
-      }
-      const now = new Date();
-      const start = new Date(startedAt);
-      const diff = Math.floor((now - start) / 1000); // seconds
-
-      const hours = Math.floor(diff / 3600);
-      const minutes = Math.floor((diff % 3600) / 60);
-      const seconds = diff % 60;
-
-      if (hours > 0) {
-        setElapsed(
-          `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`
-        );
-      } else {
-        setElapsed(
-          `${minutes}:${String(seconds).padStart(2, '0')}`
-        );
-      }
+      setElapsed(calculateElapsed(startedAt));
     }, 1000);
 
     return () => clearInterval(interval);

--- a/src/components/SessionHeader.test.jsx
+++ b/src/components/SessionHeader.test.jsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import SessionHeader from './SessionHeader';
+
+// Advance timer by N seconds, flushing React effects after each tick
+function tickSeconds(n) {
+  for (let i = 0; i < n; i++) {
+    act(() => { vi.advanceTimersByTime(1000); });
+  }
+}
+
+describe('SessionHeader elapsed time', () => {
+  let onCancel;
+  let onTimerOpen;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    onCancel = vi.fn();
+    onTimerOpen = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('initializes elapsed to 0:00 for new session', () => {
+    const now = new Date('2026-07-16T10:00:00Z');
+    vi.setSystemTime(now);
+
+    render(
+      <SessionHeader
+        workoutTitle="Upper A"
+        startedAt={now.toISOString()}
+        onCancel={onCancel}
+        onTimerOpen={onTimerOpen}
+      />
+    );
+
+    expect(screen.getByText('0:00')).toBeTruthy();
+  });
+
+  it('initializes elapsed to ~17:00 for resumed session started 17 minutes ago', () => {
+    const now = new Date('2026-07-16T10:17:00Z');
+    const startedAt = new Date('2026-07-16T10:00:00Z');
+    vi.setSystemTime(now);
+
+    render(
+      <SessionHeader
+        workoutTitle="Upper A"
+        startedAt={startedAt.toISOString()}
+        onCancel={onCancel}
+        onTimerOpen={onTimerOpen}
+      />
+    );
+
+    // Should immediately show ~17 minutes, not 0:00
+    expect(screen.getByText('17:00')).toBeTruthy();
+  });
+
+  it('continues ticking after initial render', () => {
+    const now = new Date('2026-07-16T10:17:00Z');
+    const startedAt = new Date('2026-07-16T10:00:00Z');
+    vi.setSystemTime(now);
+
+    render(
+      <SessionHeader
+        workoutTitle="Upper A"
+        startedAt={startedAt.toISOString()}
+        onCancel={onCancel}
+        onTimerOpen={onTimerOpen}
+      />
+    );
+
+    expect(screen.getByText('17:00')).toBeTruthy();
+
+    tickSeconds(5);
+    expect(screen.getByText('17:05')).toBeTruthy();
+  });
+
+  it('handles invalid startedAt gracefully', () => {
+    render(
+      <SessionHeader
+        workoutTitle="Upper A"
+        startedAt="invalid"
+        onCancel={onCancel}
+        onTimerOpen={onTimerOpen}
+      />
+    );
+
+    expect(screen.getByText('0:00')).toBeTruthy();
+  });
+
+  it('handles missing startedAt gracefully', () => {
+    render(
+      <SessionHeader
+        workoutTitle="Upper A"
+        startedAt={null}
+        onCancel={onCancel}
+        onTimerOpen={onTimerOpen}
+      />
+    );
+
+    expect(screen.getByText('0:00')).toBeTruthy();
+  });
+
+  it('formats hours correctly when elapsed exceeds 60 minutes', () => {
+    const now = new Date('2026-07-16T12:05:00Z');
+    const startedAt = new Date('2026-07-16T10:00:00Z');
+    vi.setSystemTime(now);
+
+    render(
+      <SessionHeader
+        workoutTitle="Upper A"
+        startedAt={startedAt.toISOString()}
+        onCancel={onCancel}
+        onTimerOpen={onTimerOpen}
+      />
+    );
+
+    expect(screen.getByText('2:05:00')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes SessionHeader elapsed time display for resumed workout sessions. Previously the component initialized `elapsed` to `'0:00'` and only updated it inside a 1-second interval, guaranteeing a stale first render for any resumed session. Now it calculates elapsed time synchronously on mount and continues updating every second.

## Changes

- Extracted elapsed time calculation logic into `calculateElapsed()` pure function
- Initialize `elapsed` state with lazy initializer calling `calculateElapsed(startedAt)`
- Call `calculateElapsed()` immediately in useEffect when `startedAt` changes
- All existing behavior preserved: hourly formatting, invalid timestamp handling, per-second updates

## Testing

Added `src/components/SessionHeader.test.jsx` with fake-timer unit coverage:
- ✅ New sessions display `0:00` initially
- ✅ Resumed sessions started 17 minutes ago immediately display `17:00`, not `0:00`
- ✅ Timer continues ticking after initial render
- ✅ Invalid/missing `startedAt` safely displays `0:00`
- ✅ Hours format correctly when elapsed exceeds 60 minutes

All unit tests (441 passed), E2E tests (67 passed, 3 skipped), and production build validated.

## Decisions

Used lazy state initializer pattern (`useState(() => calculateElapsed(startedAt))`) to avoid computing elapsed time on every render, only on mount. This is React's recommended approach for expensive initialization.

## Review notes

**Dual-model code review (GPT-5.5 + Claude Opus 4.8):**
- ✅ No code quality or correctness issues found (GPT-5.5)
- ✅ No security vulnerabilities found (Claude Opus 4.8)

Closes #30
