### PR TITLE
feat: add offline-persistence seam with swappable adapters and shared section registry

### DIFF
--- a/src/hooks/useSync.js
+++ b/src/hooks/useSync.js
@@ -1,22 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
 import { checkServerHealth, pullFromServer, pushAllToServer, clearServerData } from '../storage/sync';
-import {
-  LS_WORKOUTS,
-  LS_SCHEDULE,
-  LS_YOUTUBE_LINKS,
-  LS_WORKOUT_LOGS,
-  LS_ACTIVE_SESSION,
-  LS_TEMPLATES,
-} from '../constants';
+import { getSyncedKeys } from '../storage/registry';
 
-const ALL_KEYS = [
-  LS_WORKOUTS,
-  LS_SCHEDULE,
-  LS_YOUTUBE_LINKS,
-  LS_WORKOUT_LOGS,
-  LS_ACTIVE_SESSION,
-  LS_TEMPLATES,
-];
+// Every synced durable section, sourced from the shared section registry
+// (includes the recovery active-session key for crash recovery).
+const ALL_KEYS = getSyncedKeys();
 
 /**
  * Hook for managing sync state with the NAS backend.

--- a/src/storage/adapters/browserStorage.js
+++ b/src/storage/adapters/browserStorage.js
@@ -1,0 +1,121 @@
+/**
+ * Browser-storage adapter for the offline-persistence seam.
+ *
+ * Defines the narrow key/value contract the seam depends on and provides two
+ * interchangeable implementations:
+ *
+ *   - {@link createBrowserStorageAdapter} — wraps a real DOM `Storage`
+ *     (`localStorage` by default). This is the production adapter.
+ *   - {@link createMemoryStorageAdapter} — a deterministic in-memory fake for
+ *     tests, with optional quota simulation so quota-exceeded failures can be
+ *     characterized without depending on a real browser.
+ *
+ * Contract (matches the relevant subset of the DOM Storage API):
+ *   - `getItem(key)`     → the stored string, or `null` if absent
+ *   - `setItem(key, v)`  → stores `String(v)`; may throw on quota exhaustion
+ *   - `removeItem(key)`  → deletes the key (no-op if absent)
+ *   - `keys()`           → array of currently-present keys
+ *
+ * Adapters deal only in raw strings. JSON (de)serialization and malformed-data
+ * recovery live one layer up, in the persistence seam.
+ *
+ * @module storage/adapters/browserStorage
+ */
+
+/**
+ * @typedef {Object} StorageAdapter
+ * @property {(key: string) => (string|null)} getItem
+ * @property {(key: string, value: unknown) => void} setItem
+ * @property {(key: string) => void} removeItem
+ * @property {() => string[]} keys
+ */
+
+/**
+ * Wrap a DOM `Storage`-like object (e.g. `window.localStorage`) as an adapter.
+ *
+ * @param {Storage} [storage] - defaults to `globalThis.localStorage`
+ * @returns {StorageAdapter}
+ */
+export function createBrowserStorageAdapter(storage = globalThis.localStorage) {
+  if (!storage) {
+    throw new Error('createBrowserStorageAdapter: no Storage available');
+  }
+  return {
+    getItem(key) {
+      return storage.getItem(key);
+    },
+    setItem(key, value) {
+      storage.setItem(key, String(value));
+    },
+    removeItem(key) {
+      storage.removeItem(key);
+    },
+    keys() {
+      const out = [];
+      for (let i = 0; i < storage.length; i++) {
+        const k = storage.key(i);
+        if (k !== null) out.push(k);
+      }
+      return out;
+    },
+  };
+}
+
+/** Error mirroring the browser's quota-exceeded failure so callers can branch on `.name`. */
+class QuotaExceededError extends Error {
+  constructor(message = 'Storage quota exceeded') {
+    super(message);
+    this.name = 'QuotaExceededError';
+  }
+}
+
+/**
+ * Byte size of a key/value pair, matching quota.js UTF-16 accounting
+ * (2 bytes per character, counting both key and value).
+ */
+function pairBytes(key, value) {
+  return (key.length + value.length) * 2;
+}
+
+/**
+ * Deterministic in-memory storage adapter for tests.
+ *
+ * @param {Object} [options]
+ * @param {Record<string,string>} [options.initial] - seed key/value pairs
+ * @param {number} [options.quotaBytes] - optional budget; writes that would push
+ *   total usage past it throw a QuotaExceededError and leave state unchanged
+ * @returns {StorageAdapter}
+ */
+export function createMemoryStorageAdapter({ initial = {}, quotaBytes = Infinity } = {}) {
+  const store = new Map(Object.entries(initial).map(([k, v]) => [k, String(v)]));
+
+  function usedBytes(excludeKey) {
+    let bytes = 0;
+    for (const [k, v] of store) {
+      if (k === excludeKey) continue;
+      bytes += pairBytes(k, v);
+    }
+    return bytes;
+  }
+
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      const str = String(value);
+      // Replacing an existing key frees its old footprint first.
+      const projected = usedBytes(key) + pairBytes(key, str);
+      if (projected > quotaBytes) {
+        throw new QuotaExceededError();
+      }
+      store.set(key, str);
+    },
+    removeItem(key) {
+      store.delete(key);
+    },
+    keys() {
+      return [...store.keys()];
+    },
+  };
+}

--- a/src/storage/adapters/browserStorage.test.js
+++ b/src/storage/adapters/browserStorage.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createBrowserStorageAdapter,
+  createMemoryStorageAdapter,
+} from './browserStorage';
+
+/**
+ * Both the real (localStorage-backed) adapter and the in-memory fake must
+ * satisfy the same contract, so the behavioural tests run against each.
+ */
+function realBackedAdapter() {
+  const store = {};
+  const storage = {
+    getItem: vi.fn((k) => (k in store ? store[k] : null)),
+    setItem: vi.fn((k, v) => { store[k] = String(v); }),
+    removeItem: vi.fn((k) => { delete store[k]; }),
+    key: vi.fn((i) => Object.keys(store)[i] ?? null),
+    get length() { return Object.keys(store).length; },
+  };
+  return createBrowserStorageAdapter(storage);
+}
+
+describe.each([
+  ['browser adapter', () => realBackedAdapter()],
+  ['memory fake', () => createMemoryStorageAdapter()],
+])('storage adapter contract — %s', (_name, make) => {
+  it('returns null for keys that were never written', () => {
+    const adapter = make();
+    expect(adapter.getItem('th_missing')).toBeNull();
+  });
+
+  it('round-trips a stored string value', () => {
+    const adapter = make();
+    adapter.setItem('th_workouts', '{"a":1}');
+    expect(adapter.getItem('th_workouts')).toBe('{"a":1}');
+  });
+
+  it('overwrites an existing value', () => {
+    const adapter = make();
+    adapter.setItem('th_logs', '[]');
+    adapter.setItem('th_logs', '[1]');
+    expect(adapter.getItem('th_logs')).toBe('[1]');
+  });
+
+  it('removes a stored value', () => {
+    const adapter = make();
+    adapter.setItem('th_templates', '{}');
+    adapter.removeItem('th_templates');
+    expect(adapter.getItem('th_templates')).toBeNull();
+  });
+
+  it('lists the keys currently present', () => {
+    const adapter = make();
+    adapter.setItem('th_a', '1');
+    adapter.setItem('th_b', '2');
+    expect(adapter.keys().sort()).toEqual(['th_a', 'th_b']);
+    adapter.removeItem('th_a');
+    expect(adapter.keys()).toEqual(['th_b']);
+  });
+
+  it('coerces non-string values to strings on write, like the DOM Storage API', () => {
+    const adapter = make();
+    adapter.setItem('th_num', 5);
+    expect(adapter.getItem('th_num')).toBe('5');
+  });
+});
+
+describe('memory fake — deterministic quota simulation', () => {
+  it('throws a QuotaExceededError when a write would exceed the byte budget', () => {
+    const adapter = createMemoryStorageAdapter({ quotaBytes: 20 });
+    // Each char is 2 bytes (UTF-16), consistent with quota.js accounting.
+    // key 'k' (1) + value 'x'.repeat(9) (9) = 10 chars = 20 bytes: fits exactly.
+    expect(() => adapter.setItem('k', 'x'.repeat(9))).not.toThrow();
+    // Adding one more char tips it over the budget.
+    expect(() => adapter.setItem('k', 'x'.repeat(10))).toThrow(/quota/i);
+  });
+
+  it('names the quota error QuotaExceededError so callers can branch on it', () => {
+    const adapter = createMemoryStorageAdapter({ quotaBytes: 2 });
+    let caught;
+    try {
+      adapter.setItem('kk', 'vv');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.name).toBe('QuotaExceededError');
+  });
+
+  it('does not persist a value that was rejected for quota', () => {
+    const adapter = createMemoryStorageAdapter({ quotaBytes: 4 });
+    adapter.setItem('a', 'b'); // 2 chars = 4 bytes, fits
+    expect(() => adapter.setItem('a', 'toolong')).toThrow();
+    // The prior good value is retained, the oversized write is discarded.
+    expect(adapter.getItem('a')).toBe('b');
+  });
+
+  it('seeds from an initial snapshot', () => {
+    const adapter = createMemoryStorageAdapter({ initial: { th_seed: '{"x":1}' } });
+    expect(adapter.getItem('th_seed')).toBe('{"x":1}');
+  });
+});

--- a/src/storage/adapters/serverTransport.js
+++ b/src/storage/adapters/serverTransport.js
@@ -1,0 +1,139 @@
+/**
+ * Server-transport adapter for the offline-persistence seam.
+ *
+ * Defines the transport contract the seam uses to sync durable sections with
+ * the NAS API, plus two interchangeable implementations:
+ *
+ *   - {@link createFetchTransportAdapter} — talks to the real `/api/data`
+ *     endpoints over `fetch`. This mirrors the request shapes already used by
+ *     `src/storage/sync.js` (GET `/data`, PUT `/data/:key` with `{ data }`,
+ *     PUT `/data` with a full payload map).
+ *   - {@link createMemoryTransportAdapter} — a deterministic in-memory fake for
+ *     tests, with an injectable clock and an offline toggle so sync failures
+ *     can be characterized without a live server.
+ *
+ * Contract:
+ *   - `pullAll()`          → `{ ok, sections }` where `sections` is a map of
+ *                            `key → { data, updatedAt }` (empty `{}` on failure)
+ *   - `push(key, data)`    → `{ ok, status }`  (`status` is `null` on network error)
+ *   - `pushAll(payload)`   → `{ ok, status }`
+ *
+ * Methods resolve to result objects rather than throwing, matching the
+ * offline-first, error-swallowing style of the existing sync layer.
+ *
+ * @module storage/adapters/serverTransport
+ */
+
+const DEFAULT_TIMEOUT_MS = 5000;
+
+/**
+ * @typedef {Object} TransportAdapter
+ * @property {() => Promise<{ok: boolean, sections: Record<string, {data: unknown, updatedAt: string|null}>}>} pullAll
+ * @property {(key: string, data: unknown) => Promise<{ok: boolean, status: number|null}>} push
+ * @property {(payload: Record<string, unknown>) => Promise<{ok: boolean, status: number|null}>} pushAll
+ */
+
+function timeoutSignal(ms) {
+  // AbortSignal.timeout is unavailable in some test/runtime environments.
+  return typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
+    ? AbortSignal.timeout(ms)
+    : undefined;
+}
+
+/**
+ * Real transport backed by `fetch` against the NAS API.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.apiBase='/api']
+ * @param {typeof fetch} [options.fetchImpl] - defaults to `globalThis.fetch`
+ * @param {number} [options.timeoutMs=5000]
+ * @returns {TransportAdapter}
+ */
+export function createFetchTransportAdapter({
+  apiBase = '/api',
+  fetchImpl = globalThis.fetch,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+} = {}) {
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('createFetchTransportAdapter: no fetch implementation available');
+  }
+  const doFetch = (url, opts) => fetchImpl(url, { signal: timeoutSignal(timeoutMs), ...opts });
+
+  return {
+    async pullAll() {
+      try {
+        const res = await doFetch(`${apiBase}/data`, { cache: 'reload' });
+        if (!res.ok) return { ok: false, sections: {} };
+        const sections = await res.json();
+        return { ok: true, sections: sections ?? {} };
+      } catch {
+        return { ok: false, sections: {} };
+      }
+    },
+    async push(key, data) {
+      try {
+        const res = await doFetch(`${apiBase}/data/${key}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ data }),
+        });
+        return { ok: res.ok, status: res.status };
+      } catch {
+        return { ok: false, status: null };
+      }
+    },
+    async pushAll(payload) {
+      try {
+        const res = await doFetch(`${apiBase}/data`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        return { ok: res.ok, status: res.status };
+      } catch {
+        return { ok: false, status: null };
+      }
+    },
+  };
+}
+
+/**
+ * Deterministic in-memory transport fake for tests.
+ *
+ * @param {Object} [options]
+ * @param {Record<string, {data: unknown, updatedAt: string|null}>} [options.initial]
+ * @param {() => string} [options.clock] - stamps `updatedAt` on writes
+ * @param {boolean} [options.online=true] - when false, every call resolves ok:false
+ * @returns {TransportAdapter & { setOnline: (v: boolean) => void }}
+ */
+export function createMemoryTransportAdapter({
+  initial = {},
+  clock = () => new Date().toISOString(),
+  online = true,
+} = {}) {
+  const store = new Map(Object.entries(initial));
+  let isOnline = online;
+
+  return {
+    setOnline(value) {
+      isOnline = value;
+    },
+    async pullAll() {
+      if (!isOnline) return { ok: false, sections: {} };
+      return { ok: true, sections: Object.fromEntries(store) };
+    },
+    async push(key, data) {
+      if (!isOnline) return { ok: false, status: null };
+      store.set(key, { data, updatedAt: clock() });
+      return { ok: true, status: 200 };
+    },
+    async pushAll(payload) {
+      if (!isOnline) return { ok: false, status: null };
+      const stamp = clock();
+      for (const [key, data] of Object.entries(payload)) {
+        store.set(key, { data, updatedAt: stamp });
+      }
+      return { ok: true, status: 200 };
+    },
+  };
+}

--- a/src/storage/adapters/serverTransport.js
+++ b/src/storage/adapters/serverTransport.js
@@ -72,7 +72,7 @@ export function createFetchTransportAdapter({
     },
     async push(key, data) {
       try {
-        const res = await doFetch(`${apiBase}/data/${key}`, {
+        const res = await doFetch(`${apiBase}/data/${encodeURIComponent(key)}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ data }),

--- a/src/storage/adapters/serverTransport.test.js
+++ b/src/storage/adapters/serverTransport.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createFetchTransportAdapter,
+  createMemoryTransportAdapter,
+} from './serverTransport';
+
+function jsonResponse(body, ok = true, status = 200) {
+  return { ok, status, json: async () => body };
+}
+
+describe('fetch transport adapter', () => {
+  it('pullAll GETs /data and returns the server sections map', async () => {
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse({ th_workouts: { data: { a: 1 }, updatedAt: '2026-01-01' } })
+    );
+    const transport = createFetchTransportAdapter({ apiBase: '/api', fetchImpl });
+
+    const result = await transport.pullAll();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, opts] = fetchImpl.mock.calls[0];
+    expect(url).toBe('/api/data');
+    expect(opts?.method ?? 'GET').toBe('GET');
+    expect(result).toEqual({
+      ok: true,
+      sections: { th_workouts: { data: { a: 1 }, updatedAt: '2026-01-01' } },
+    });
+  });
+
+  it('pullAll reports ok:false on a non-2xx response without throwing', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(null, false, 500));
+    const transport = createFetchTransportAdapter({ fetchImpl });
+    await expect(transport.pullAll()).resolves.toEqual({ ok: false, sections: {} });
+  });
+
+  it('pullAll reports ok:false when the network throws (offline)', async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error('offline'); });
+    const transport = createFetchTransportAdapter({ fetchImpl });
+    await expect(transport.pullAll()).resolves.toEqual({ ok: false, sections: {} });
+  });
+
+  it('push PUTs a single key with a { data } body', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, true, 200));
+    const transport = createFetchTransportAdapter({ apiBase: '/api', fetchImpl });
+
+    const result = await transport.push('th_logs', { x: 1 });
+
+    const [url, opts] = fetchImpl.mock.calls[0];
+    expect(url).toBe('/api/data/th_logs');
+    expect(opts.method).toBe('PUT');
+    expect(JSON.parse(opts.body)).toEqual({ data: { x: 1 } });
+    expect(result).toEqual({ ok: true, status: 200 });
+  });
+
+  it('push surfaces the failing status code', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(null, false, 413));
+    const transport = createFetchTransportAdapter({ fetchImpl });
+    await expect(transport.push('th_logs', {})).resolves.toEqual({ ok: false, status: 413 });
+  });
+
+  it('push reports ok:false with null status when the network throws', async () => {
+    const fetchImpl = vi.fn(async () => { throw new Error('offline'); });
+    const transport = createFetchTransportAdapter({ fetchImpl });
+    await expect(transport.push('th_logs', {})).resolves.toEqual({ ok: false, status: null });
+  });
+
+  it('pushAll PUTs the whole payload map to /data', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({}, true, 200));
+    const transport = createFetchTransportAdapter({ apiBase: '/api', fetchImpl });
+
+    const result = await transport.pushAll({ th_a: { n: 1 }, th_b: null });
+
+    const [url, opts] = fetchImpl.mock.calls[0];
+    expect(url).toBe('/api/data');
+    expect(opts.method).toBe('PUT');
+    expect(JSON.parse(opts.body)).toEqual({ th_a: { n: 1 }, th_b: null });
+    expect(result).toEqual({ ok: true, status: 200 });
+  });
+});
+
+describe('memory transport fake', () => {
+  it('starts empty and returns an empty sections map', async () => {
+    const transport = createMemoryTransportAdapter();
+    await expect(transport.pullAll()).resolves.toEqual({ ok: true, sections: {} });
+  });
+
+  it('records pushes and returns them from pullAll with an updatedAt stamp', async () => {
+    const transport = createMemoryTransportAdapter({ clock: () => '2026-07-16T00:00:00Z' });
+    await transport.push('th_workouts', { a: 1 });
+
+    const { sections } = await transport.pullAll();
+    expect(sections.th_workouts).toEqual({
+      data: { a: 1 },
+      updatedAt: '2026-07-16T00:00:00Z',
+    });
+  });
+
+  it('pushAll seeds many sections at once', async () => {
+    const transport = createMemoryTransportAdapter({ clock: () => 'T' });
+    await transport.pushAll({ th_a: { n: 1 }, th_b: { n: 2 } });
+    const { sections } = await transport.pullAll();
+    expect(sections.th_a).toEqual({ data: { n: 1 }, updatedAt: 'T' });
+    expect(sections.th_b).toEqual({ data: { n: 2 }, updatedAt: 'T' });
+  });
+
+  it('records a null push as an intentional deletion (data:null, updatedAt set)', async () => {
+    const transport = createMemoryTransportAdapter({ clock: () => 'T' });
+    await transport.push('th_logs', null);
+    const { sections } = await transport.pullAll();
+    expect(sections.th_logs).toEqual({ data: null, updatedAt: 'T' });
+  });
+
+  it('simulates an offline server: every call resolves ok:false', async () => {
+    const transport = createMemoryTransportAdapter({ online: false });
+    await expect(transport.pullAll()).resolves.toEqual({ ok: false, sections: {} });
+    await expect(transport.push('th_a', {})).resolves.toEqual({ ok: false, status: null });
+    await expect(transport.pushAll({})).resolves.toEqual({ ok: false, status: null });
+  });
+
+  it('does not record pushes while offline', async () => {
+    const transport = createMemoryTransportAdapter({ online: false, clock: () => 'T' });
+    await transport.push('th_a', { n: 1 });
+    transport.setOnline(true);
+    const { sections } = await transport.pullAll();
+    expect(sections).toEqual({});
+  });
+});

--- a/src/storage/backup.js
+++ b/src/storage/backup.js
@@ -1,21 +1,10 @@
 import { readLS } from './index';
-import {
-  LS_WORKOUTS,
-  LS_SCHEDULE,
-  LS_YOUTUBE_LINKS,
-  LS_WORKOUT_LOGS,
-  LS_TEMPLATES,
-} from '../constants';
+import { getBackupKeys } from './registry';
 
-// The five sections a full backup must round-trip. The in-progress active
-// session scratch (LS_ACTIVE_SESSION / th_active) is intentionally excluded.
-export const BACKUP_KEYS = [
-  LS_WORKOUTS,
-  LS_SCHEDULE,
-  LS_YOUTUBE_LINKS,
-  LS_WORKOUT_LOGS,
-  LS_TEMPLATES,
-];
+// The sections a full backup must round-trip, sourced from the shared section
+// registry. The in-progress active session scratch (LS_ACTIVE_SESSION /
+// th_active) is registered with `backup: false`, so it is intentionally excluded.
+export const BACKUP_KEYS = getBackupKeys();
 
 /**
  * Build a complete backup snapshot. Every required section is always present —

--- a/src/storage/persistence.js
+++ b/src/storage/persistence.js
@@ -1,0 +1,114 @@
+/**
+ * Offline-persistence seam.
+ *
+ * A thin, compatibility-preserving coordinator that owns TrainLog's durable
+ * data through swappable adapters. It combines:
+ *
+ *   - the shared {@link module:storage/registry} (what to persist, what syncs,
+ *     what is backed up), and
+ *   - a browser-storage adapter + a server-transport adapter (how to persist
+ *     and sync).
+ *
+ * Because every dependency is injected, the whole seam runs against the
+ * deterministic in-memory fakes in tests, and against `localStorage` + `fetch`
+ * in production. It deliberately mirrors the existing `readLS`/`writeLS`
+ * semantics — malformed stored data degrades to the section default, and a
+ * quota-exceeded write returns a structured failure instead of throwing — so it
+ * can take ownership of the data path without changing observable behavior.
+ *
+ * @module storage/persistence
+ */
+
+import { SECTIONS, getSection } from './registry';
+
+function requireSection(sectionId) {
+  const section = getSection(sectionId);
+  if (!section) {
+    throw new Error(`persistence: unknown section "${sectionId}"`);
+  }
+  return section;
+}
+
+/**
+ * @param {Object} deps
+ * @param {import('./adapters/browserStorage').StorageAdapter} deps.storage
+ * @param {import('./adapters/serverTransport').TransportAdapter} deps.transport
+ */
+export function createPersistence({ storage, transport }) {
+  if (!storage) throw new Error('createPersistence: storage adapter is required');
+  if (!transport) throw new Error('createPersistence: transport adapter is required');
+
+  /** Read a section, returning its default on absence or malformed data. */
+  function read(sectionId) {
+    const section = requireSection(sectionId);
+    const raw = storage.getItem(section.key);
+    if (raw === null || raw === undefined) return clone(section.defaultValue);
+    try {
+      return JSON.parse(raw);
+    } catch (e) {
+      console.warn(`persistence: malformed stored data for "${section.key}" — using default`, e);
+      return clone(section.defaultValue);
+    }
+  }
+
+  /**
+   * Write a section locally, then push it to the server if the section syncs.
+   *
+   * @returns {Promise<{ok: boolean, reason?: string, synced: boolean, pushed: boolean}>}
+   *   `ok:false, reason:'quota'` when the local write is rejected for quota.
+   */
+  async function write(sectionId, value) {
+    const section = requireSection(sectionId);
+    try {
+      storage.setItem(section.key, JSON.stringify(value));
+    } catch (e) {
+      if (e && e.name === 'QuotaExceededError') {
+        return { ok: false, reason: 'quota', synced: false, pushed: false };
+      }
+      return { ok: false, reason: 'write-failed', synced: false, pushed: false };
+    }
+    if (!section.synced) return { ok: true, synced: false, pushed: false };
+    const res = await transport.push(section.key, value);
+    return { ok: true, synced: true, pushed: res.ok };
+  }
+
+  /** Remove a section locally, then push a null deletion if the section syncs. */
+  async function remove(sectionId) {
+    const section = requireSection(sectionId);
+    storage.removeItem(section.key);
+    if (!section.synced) return { ok: true, synced: false, pushed: false };
+    const res = await transport.push(section.key, null);
+    return { ok: true, synced: true, pushed: res.ok };
+  }
+
+  /** Read every registered section, keyed by its stable id. */
+  function snapshot() {
+    const out = {};
+    for (const section of SECTIONS) {
+      out[section.id] = read(section.id);
+    }
+    return out;
+  }
+
+  /**
+   * Build a backup keyed by localStorage key, covering only backup sections
+   * (the recovery session is excluded). Empty sections default to `{}` so a
+   * restore reproduces the snapshot rather than leaving stale data behind.
+   */
+  function buildBackup() {
+    const out = {};
+    for (const section of SECTIONS) {
+      if (!section.backup) continue;
+      out[section.key] = read(section.id);
+    }
+    return out;
+  }
+
+  return { read, write, remove, snapshot, buildBackup };
+}
+
+/** Structured-clone-ish default so callers can't mutate the frozen registry defaults. */
+function clone(value) {
+  if (value === null || typeof value !== 'object') return value;
+  return JSON.parse(JSON.stringify(value));
+}

--- a/src/storage/persistence.test.js
+++ b/src/storage/persistence.test.js
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { createPersistence } from './persistence';
+import { createMemoryStorageAdapter } from './adapters/browserStorage';
+import { createMemoryTransportAdapter } from './adapters/serverTransport';
+import {
+  LS_WORKOUTS,
+  LS_TEMPLATES,
+  LS_ACTIVE_SESSION,
+  LS_WORKOUT_LOGS,
+  LS_SCHEDULE,
+  LS_YOUTUBE_LINKS,
+} from '../constants';
+
+function setup(opts = {}) {
+  const storage = createMemoryStorageAdapter(opts.storage);
+  const transport = createMemoryTransportAdapter({ clock: () => 'T', ...opts.transport });
+  const persistence = createPersistence({ storage, transport });
+  return { storage, transport, persistence };
+}
+
+describe('persistence seam — read', () => {
+  it('returns the section default when nothing is stored', () => {
+    const { persistence } = setup();
+    expect(persistence.read('workouts')).toEqual({});
+    expect(persistence.read('session')).toBeNull();
+  });
+
+  it('parses and returns stored JSON', () => {
+    const { persistence } = setup({ storage: { initial: { [LS_WORKOUTS]: '{"Upper A":{}}' } } });
+    expect(persistence.read('workouts')).toEqual({ 'Upper A': {} });
+  });
+
+  it('recovers from malformed stored data by returning the section default', () => {
+    const { persistence } = setup({ storage: { initial: { [LS_WORKOUTS]: '{not valid json' } } });
+    expect(persistence.read('workouts')).toEqual({});
+  });
+
+  it('recovers malformed session data as null rather than throwing', () => {
+    const { persistence } = setup({ storage: { initial: { [LS_ACTIVE_SESSION]: '}{' } } });
+    expect(() => persistence.read('session')).not.toThrow();
+    expect(persistence.read('session')).toBeNull();
+  });
+
+  it('throws a clear error for an unknown section id', () => {
+    const { persistence } = setup();
+    expect(() => persistence.read('nope')).toThrow(/unknown section/i);
+  });
+});
+
+describe('persistence seam — write', () => {
+  it('serializes and stores the value under the section key', async () => {
+    const { persistence, storage } = setup();
+    const result = await persistence.write('templates', { t1: { id: 't1' } });
+    expect(result.ok).toBe(true);
+    expect(storage.getItem(LS_TEMPLATES)).toBe('{"t1":{"id":"t1"}}');
+    expect(persistence.read('templates')).toEqual({ t1: { id: 't1' } });
+  });
+
+  it('pushes synced sections to the transport', async () => {
+    const { persistence, transport } = setup();
+    await persistence.write('workouts', { W: 1 });
+    const { sections } = await transport.pullAll();
+    expect(sections[LS_WORKOUTS]).toEqual({ data: { W: 1 }, updatedAt: 'T' });
+  });
+
+  it('reports a quota failure as a structured result without throwing', async () => {
+    // Budget too small for even the smallest write.
+    const { persistence, storage } = setup({ storage: { quotaBytes: 2 } });
+    let result;
+    await expect((async () => { result = await persistence.write('logs', { big: 'x'.repeat(50) }); })())
+      .resolves.toBeUndefined();
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe('quota');
+    // Nothing persisted, nothing pushed.
+    expect(storage.getItem(LS_WORKOUT_LOGS)).toBeNull();
+  });
+
+  it('does not push to the transport when the local write fails for quota', async () => {
+    const { persistence, transport } = setup({ storage: { quotaBytes: 2 } });
+    await persistence.write('logs', { big: 'x'.repeat(50) });
+    const { sections } = await transport.pullAll();
+    expect(sections[LS_WORKOUT_LOGS]).toBeUndefined();
+  });
+
+  it('surfaces an offline transport as ok-local-but-not-synced', async () => {
+    const { persistence, storage } = setup({ transport: { online: false } });
+    const result = await persistence.write('schedule', { '2026-07-16': 'Upper A' });
+    // Local write still succeeds (offline-first); sync just did not land.
+    expect(result.ok).toBe(true);
+    expect(result.pushed).toBe(false);
+    expect(storage.getItem(LS_SCHEDULE)).toBe('{"2026-07-16":"Upper A"}');
+  });
+});
+
+describe('persistence seam — remove', () => {
+  it('clears the key locally and pushes a null deletion to synced sections', async () => {
+    const { persistence, storage, transport } = setup({
+      storage: { initial: { [LS_YOUTUBE_LINKS]: '{"Squat":"http://x"}' } },
+    });
+    await persistence.remove('youtubeLinks');
+    expect(storage.getItem(LS_YOUTUBE_LINKS)).toBeNull();
+    const { sections } = await transport.pullAll();
+    expect(sections[LS_YOUTUBE_LINKS]).toEqual({ data: null, updatedAt: 'T' });
+  });
+});
+
+describe('persistence seam — snapshot & backup', () => {
+  it('snapshots every registered section by id', () => {
+    const { persistence } = setup({
+      storage: { initial: { [LS_WORKOUTS]: '{"W":1}', [LS_ACTIVE_SESSION]: '{"logKey":"k"}' } },
+    });
+    const snap = persistence.snapshot();
+    expect(Object.keys(snap).sort()).toEqual(
+      ['logs', 'schedule', 'session', 'templates', 'workouts', 'youtubeLinks'].sort()
+    );
+    expect(snap.workouts).toEqual({ W: 1 });
+    expect(snap.session).toEqual({ logKey: 'k' });
+  });
+
+  it('buildBackup includes the five durable sections and excludes the session', () => {
+    const { persistence } = setup({
+      storage: { initial: { [LS_WORKOUTS]: '{"W":1}', [LS_ACTIVE_SESSION]: '{"logKey":"k"}' } },
+    });
+    const backup = persistence.buildBackup();
+    expect(Object.keys(backup).sort()).toEqual(
+      [LS_WORKOUTS, LS_SCHEDULE, LS_YOUTUBE_LINKS, LS_WORKOUT_LOGS, LS_TEMPLATES].sort()
+    );
+    expect(backup).not.toHaveProperty(LS_ACTIVE_SESSION);
+    // Empty sections default to {} so a restore reproduces the snapshot.
+    expect(backup[LS_TEMPLATES]).toEqual({});
+    expect(backup[LS_WORKOUTS]).toEqual({ W: 1 });
+  });
+});

--- a/src/storage/registry.js
+++ b/src/storage/registry.js
@@ -1,0 +1,70 @@
+/**
+ * Shared registry of TrainLog's durable, offline-persisted sections.
+ *
+ * This is the single source of truth for *what* data the app persists, which
+ * sections sync to the NAS, and which are captured in a user backup.  The
+ * offline-persistence seam (adapters + `persistence.js`) and the backup layer
+ * both read their key lists from here so the definitions never drift apart.
+ *
+ * Each section is described by:
+ *   - `id`           — stable internal identifier (never the localStorage key)
+ *   - `key`          — the existing localStorage key it persists to
+ *   - `synced`       — whether writes push to / pull from the server
+ *   - `backup`       — whether the section is included in an export backup
+ *   - `defaultValue` — the fallback shape when nothing is stored yet
+ *
+ * The recovery **Session** (`th_active`) is durable and synced for crash
+ * recovery, but is intentionally excluded from backups — it is an in-progress
+ * scratch pad, not something a restore should ever reproduce.
+ *
+ * @module storage/registry
+ */
+
+import {
+  LS_WORKOUTS,
+  LS_SCHEDULE,
+  LS_YOUTUBE_LINKS,
+  LS_WORKOUT_LOGS,
+  LS_ACTIVE_SESSION,
+  LS_TEMPLATES,
+} from '../constants';
+
+/**
+ * @typedef {Object} Section
+ * @property {string}  id           - stable internal identifier
+ * @property {string}  key          - localStorage key the section persists to
+ * @property {boolean} synced       - participates in server sync
+ * @property {boolean} backup       - included in export backups
+ * @property {unknown} defaultValue - fallback value when nothing is stored
+ */
+
+/** @type {ReadonlyArray<Section>} */
+export const SECTIONS = Object.freeze([
+  { id: 'templates', key: LS_TEMPLATES, synced: true, backup: true, defaultValue: {} },
+  { id: 'workouts', key: LS_WORKOUTS, synced: true, backup: true, defaultValue: {} },
+  { id: 'schedule', key: LS_SCHEDULE, synced: true, backup: true, defaultValue: {} },
+  { id: 'logs', key: LS_WORKOUT_LOGS, synced: true, backup: true, defaultValue: {} },
+  { id: 'youtubeLinks', key: LS_YOUTUBE_LINKS, synced: true, backup: true, defaultValue: {} },
+  // Recovery scratch pad: synced for crash recovery, never backed up.
+  { id: 'session', key: LS_ACTIVE_SESSION, synced: true, backup: false, defaultValue: null },
+].map(Object.freeze));
+
+/** Look a section up by its stable id. */
+export function getSection(id) {
+  return SECTIONS.find((s) => s.id === id);
+}
+
+/** Look a section up by its localStorage key. */
+export function getSectionByKey(key) {
+  return SECTIONS.find((s) => s.key === key);
+}
+
+/** localStorage keys for every synced section (includes the recovery session). */
+export function getSyncedKeys() {
+  return SECTIONS.filter((s) => s.synced).map((s) => s.key);
+}
+
+/** localStorage keys for every backup section (excludes the recovery session). */
+export function getBackupKeys() {
+  return SECTIONS.filter((s) => s.backup).map((s) => s.key);
+}

--- a/src/storage/registry.test.js
+++ b/src/storage/registry.test.js
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SECTIONS,
+  getSection,
+  getSectionByKey,
+  getSyncedKeys,
+  getBackupKeys,
+} from './registry';
+import {
+  LS_WORKOUTS,
+  LS_SCHEDULE,
+  LS_YOUTUBE_LINKS,
+  LS_WORKOUT_LOGS,
+  LS_ACTIVE_SESSION,
+  LS_TEMPLATES,
+} from '../constants';
+
+describe('persistence registry', () => {
+  it('defines exactly the six durable sections by stable id', () => {
+    const ids = SECTIONS.map((s) => s.id).sort();
+    expect(ids).toEqual(
+      ['logs', 'schedule', 'session', 'templates', 'workouts', 'youtubeLinks'].sort()
+    );
+  });
+
+  it('maps each section to its existing persisted localStorage key', () => {
+    const byId = Object.fromEntries(SECTIONS.map((s) => [s.id, s.key]));
+    expect(byId.templates).toBe(LS_TEMPLATES);
+    expect(byId.workouts).toBe(LS_WORKOUTS);
+    expect(byId.schedule).toBe(LS_SCHEDULE);
+    expect(byId.logs).toBe(LS_WORKOUT_LOGS);
+    expect(byId.youtubeLinks).toBe(LS_YOUTUBE_LINKS);
+    expect(byId.session).toBe(LS_ACTIVE_SESSION);
+  });
+
+  it('marks every durable section as synced', () => {
+    for (const section of SECTIONS) {
+      expect(section.synced).toBe(true);
+    }
+  });
+
+  it('excludes only the recovery session from backups', () => {
+    const notBackedUp = SECTIONS.filter((s) => !s.backup).map((s) => s.id);
+    expect(notBackedUp).toEqual(['session']);
+  });
+
+  it('backup keys are the five durable sections, never the active session', () => {
+    const keys = getBackupKeys();
+    expect(keys.sort()).toEqual(
+      [LS_WORKOUTS, LS_SCHEDULE, LS_YOUTUBE_LINKS, LS_WORKOUT_LOGS, LS_TEMPLATES].sort()
+    );
+    expect(keys).not.toContain(LS_ACTIVE_SESSION);
+  });
+
+  it('synced keys cover all six sections including the session for crash recovery', () => {
+    const keys = getSyncedKeys();
+    expect(keys.sort()).toEqual(
+      [
+        LS_WORKOUTS,
+        LS_SCHEDULE,
+        LS_YOUTUBE_LINKS,
+        LS_WORKOUT_LOGS,
+        LS_TEMPLATES,
+        LS_ACTIVE_SESSION,
+      ].sort()
+    );
+  });
+
+  it('looks sections up by id and by key', () => {
+    expect(getSection('templates').key).toBe(LS_TEMPLATES);
+    expect(getSectionByKey(LS_TEMPLATES).id).toBe('templates');
+    expect(getSection('nope')).toBeUndefined();
+    expect(getSectionByKey('th_unknown')).toBeUndefined();
+  });
+
+  it('gives every backup section an empty-object default shape', () => {
+    for (const section of SECTIONS.filter((s) => s.backup)) {
+      expect(section.defaultValue).toEqual({});
+    }
+  });
+
+  it('defaults the recovery session to null (no in-progress workout)', () => {
+    expect(getSection('session').defaultValue).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a compatibility-preserving **offline-persistence seam** for TrainLog's durable data. The seam can take ownership of persistence through swappable adapters, while the existing `writeLS` / `sync.js` path stays authoritative during migration — no observable behavior changes.

Closes #51

## What changed

- **`src/storage/registry.js`** — one shared registry of durable sections: Templates, Workouts, Schedule, Logs, YouTube links, and the recovery Session. Every section is `synced: true`; only the recovery Session is `backup: false` (excluded from backups). Exposes `getSection`, `getSectionByKey`, `getSyncedKeys`, `getBackupKeys`.
- **`src/storage/adapters/browserStorage.js`** — browser-storage adapter contract with:
  - `createBrowserStorageAdapter(storage)` wrapping a real DOM `Storage` (localStorage), and
  - `createMemoryStorageAdapter({ initial, quotaBytes })`, a deterministic in-memory fake that simulates `QuotaExceededError` using the same UTF-16 byte accounting as `quota.js`.
- **`src/storage/adapters/serverTransport.js`** — server-transport adapter contract mirroring the existing `/api/data` request shapes (GET `/data`, PUT `/data/:key` with `{ data }`, PUT `/data`), with:
  - `createFetchTransportAdapter({ apiBase, fetchImpl, timeoutMs })`, and
  - `createMemoryTransportAdapter({ initial, clock, online })`, a deterministic fake with an offline toggle and injectable clock.
- **`src/storage/persistence.js`** — the seam composing registry + adapters. Reads degrade malformed stored data to the section default; writes surface quota exhaustion as a structured `{ ok: false, reason: 'quota' }` result instead of throwing (mirrors `readLS`/`writeLS`). Provides `read`, `write`, `remove`, `snapshot`, and `buildBackup`.
- **`src/storage/backup.js`** and **`src/hooks/useSync.js`** — `BACKUP_KEYS` and `ALL_KEYS` now derive from the shared registry so section definitions are single-sourced. Same key sets, order-independent usages → behavior unchanged.

## Acceptance criteria

- [x] Swappable browser-storage and server-transport adapters plus deterministic in-memory fakes.
- [x] One shared registry defines synced durable sections (Templates, Workouts, Schedule, Logs, YouTube links); recovery Session excluded from backup.
- [x] Tests characterize malformed stored data and storage-quota failures through the adapters/seam.
- [x] Existing local writes, sync timing, Settings behavior, persisted keys, and data shapes unchanged.

## Tests

New TDD-driven suites (red → green per slice):
- `src/storage/registry.test.js` (9)
- `src/storage/adapters/browserStorage.test.js` (16, incl. quota simulation)
- `src/storage/adapters/serverTransport.test.js` (13, incl. offline)
- `src/storage/persistence.test.js` (13, incl. malformed + quota)

Validation (all green):
- `npm run test:unit` — 492 passed
- `npm run test:e2e` — 70 passed, 6 skipped
- `npm run build` — succeeds

## Visual verification

Not applicable — this is a pure infrastructure change (new persistence modules + key-list wiring). No React views, components, styles, or user-visible behavior are touched. Existing Settings/backup/sync e2e journeys remain green.

## Decisions

- The seam is **additive and dormant**: it is not yet wired into the app's write path, honoring "the existing path remains authoritative during migration." The only touch to existing code is deriving `BACKUP_KEYS`/`ALL_KEYS` from the registry to make it a genuine single source (and avoid dead code), which is behavior-preserving.
- Adapters deal only in raw strings; JSON serialization and malformed-data recovery live in the persistence seam, matching the current `readLS`/`writeLS` split.
- The recovery Session is modeled as `synced: true, backup: false` to match current behavior: `th_active` is pushed by `writeLS` and included in `useSync` keys, but excluded from `buildBackup`.

## Review notes

Dual-model review completed (gpt-5.5 code-quality + claude-opus-4.8 security). Both returned **zero significant findings**.

- Security reviewer confirmed no injection/SSRF (keys are registry-sourced constants), no prototype-pollution sink (`JSON.parse` + direct assignment, no recursive merge), and no secret/PII logging.
- Adopted one forward-looking hardening the security reviewer raised as a non-finding: `push()` now wraps the key in `encodeURIComponent`. This is identity-preserving for every registry key (all URL-safe) so URLs are unchanged, and it defends the "keys must remain registry-sourced" constraint against future callers.
