### PR TITLE
feat: route local-first data hooks through the persistence authority

### DIFF
--- a/e2e/offline-journey.e2e.js
+++ b/e2e/offline-journey.e2e.js
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import {
+  gotoCleanApp,
+  importSampleCsv,
+  quickStartLowerBodyWorkout,
+  completeNextSet,
+} from './helpers';
+
+// Proves the persistence-authority migration keeps TrainLog offline-first:
+// with the network fully disabled, an athlete can still plan and log a workout,
+// and every change commits to local storage.
+test('plans and logs a workout with the network disabled', async ({ page, context }) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+
+  // Cut the network. From here every read/write must be served locally.
+  await context.setOffline(true);
+
+  // ── Plan: assign a template from the Planner while offline ───────────────
+  await page.getByRole('button', { name: 'Planner' }).click();
+  await page.getByRole('button', { name: '+ Add' }).first().click();
+  await expect(page.getByRole('heading', { name: 'Pick a Template' })).toBeVisible();
+  await page.getByRole('button', { name: /Pull Day\s+4 exercises/ }).click();
+  await expect(page.getByText('Unsaved changes')).toBeVisible();
+  await page.getByRole('button', { name: 'Apply Plan' }).click();
+  await expect(page.getByText('Unsaved changes')).not.toBeVisible();
+
+  // The plan committed locally despite having no network.
+  const scheduleRaw = await page.evaluate(() => localStorage.getItem('th_schedule'));
+  expect(scheduleRaw).toContain('Pull Day');
+
+  // ── Log: complete a full workout while offline ───────────────────────────
+  await page.getByRole('button', { name: 'Training' }).click();
+  await quickStartLowerBodyWorkout(page);
+  for (let i = 0; i < 7; i += 1) {
+    await completeNextSet(page);
+  }
+  await page.getByRole('button', { name: 'Complete Workout' }).click();
+  await expect(page.getByRole('heading', { name: 'Workout complete' })).toBeVisible();
+  await page.getByRole('button', { name: 'Done' }).click();
+
+  // History reflects the completed session — read back through the authority.
+  await page.getByRole('button', { name: 'History' }).click();
+  await expect(page.getByText('1 workout completed')).toBeVisible();
+  await expect(page.getByRole('button', { name: /Lower Body B.*7\/7 sets/ })).toBeVisible();
+
+  // The log persisted to local storage even though no request ever left.
+  const logsRaw = await page.evaluate(() => localStorage.getItem('th_logs'));
+  expect(logsRaw).toContain('Lower Body B');
+
+  await context.setOffline(false);
+});

--- a/src/hooks/createEntityHook.js
+++ b/src/hooks/createEntityHook.js
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react';
-import { readLS, writeLS, removeLS } from '../storage/index';
+import { readByKey, writeByKey, removeByKey } from '../storage/authority';
 
 /**
  * Factory for localStorage-backed React hooks.
@@ -7,26 +7,30 @@ import { readLS, writeLS, removeLS } from '../storage/index';
  * - save(value) — replace state entirely
  * - save(fn) — functional update (fn receives prev state)
  * - remove() — clear state + localStorage key
+ *
+ * All persistence is routed through the offline-persistence authority
+ * (`src/storage/authority`), which commits locally before triggering the
+ * shared background replication path.
  */
 export function createEntityHook(lsKey, defaultValue) {
   return function useEntity() {
-    const [data, setData] = useState(() => readLS(lsKey, defaultValue));
+    const [data, setData] = useState(() => readByKey(lsKey, defaultValue));
 
     const save = useCallback((valueOrUpdater) => {
       if (typeof valueOrUpdater === 'function') {
         setData((prev) => {
           const next = valueOrUpdater(prev);
-          writeLS(lsKey, next);
+          writeByKey(lsKey, next);
           return next;
         });
       } else {
-        writeLS(lsKey, valueOrUpdater);
+        writeByKey(lsKey, valueOrUpdater);
         setData(valueOrUpdater);
       }
     }, []);
 
     const remove = useCallback(() => {
-      removeLS(lsKey);
+      removeByKey(lsKey);
       setData(defaultValue);
     }, []);
 

--- a/src/hooks/createEntityHook.test.js
+++ b/src/hooks/createEntityHook.test.js
@@ -2,19 +2,19 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
-// Mock storage before importing factory
-vi.mock('../storage/index', () => {
+// Mock the persistence authority before importing factory
+vi.mock('../storage/authority', () => {
   const store = {};
   return {
-    readLS: (key, fallback) => store[key] ?? fallback,
-    writeLS: (key, value) => { store[key] = value; },
-    removeLS: (key) => { delete store[key]; },
+    readByKey: (key, fallback) => store[key] ?? fallback,
+    writeByKey: (key, value) => { store[key] = value; return Promise.resolve({ ok: true }); },
+    removeByKey: (key) => { delete store[key]; return Promise.resolve({ ok: true }); },
     __store: store,
   };
 });
 
 import { createEntityHook } from './createEntityHook';
-import { __store as store } from '../storage/index';
+import { __store as store } from '../storage/authority';
 
 beforeEach(() => {
   Object.keys(store).forEach((k) => delete store[k]);

--- a/src/storage/authority.js
+++ b/src/storage/authority.js
@@ -1,0 +1,146 @@
+/**
+ * Production wiring for the offline-persistence authority.
+ *
+ * The {@link module:storage/persistence} seam owns TrainLog's durable data but
+ * is intentionally section-id oriented and dependency-injected so it can run
+ * against in-memory fakes.  This module adapts that seam to the way the rest of
+ * the app addresses data — by *localStorage key* — and wires the production
+ * adapters:
+ *
+ *   - a browser-storage adapter over `window.localStorage`, and
+ *   - a **sync-transport adapter** whose `push` delegates to the existing
+ *     debounced/retry replication in {@link module:storage/sync} (`pushToServer`).
+ *
+ * Delegating to `pushToServer` (rather than issuing a fresh `fetch`) keeps a
+ * single background-replication path: the same 500ms debounce, the same failure
+ * retry/backoff, the same `sync-push` events the UI listens to.  The seam
+ * therefore takes ownership of the local read/write/remove path without
+ * disconnecting sync.
+ *
+ * `writeByKey`/`removeByKey` commit locally first (inside the seam) and then
+ * trigger the background push, mirroring the offline-first `writeLS`/`removeLS`
+ * contract they replace — including the quota-exceeded user alert.
+ *
+ * @module storage/authority
+ */
+
+import { createPersistence } from './persistence';
+import { createBrowserStorageAdapter } from './adapters/browserStorage';
+import { getSectionByKey } from './registry';
+import { pushToServer } from './sync';
+
+const QUOTA_ALERT_MESSAGE = 'Storage limit exceeded. Try clearing old workouts.';
+
+/**
+ * A transport adapter that forwards durable-section pushes into the shared,
+ * debounced replication path instead of issuing its own network request.
+ *
+ * @param {(key: string, data: unknown) => void} [push] - injectable for tests
+ * @returns {import('./adapters/serverTransport').TransportAdapter}
+ */
+export function createSyncTransportAdapter(push = pushToServer) {
+  return {
+    // Pulls are owned by the existing sync layer (`pullFromServer`); the
+    // authority only writes through this adapter.
+    async pullAll() {
+      return { ok: false, sections: {} };
+    },
+    async push(key, data) {
+      push(key, data);
+      return { ok: true, status: null };
+    },
+    async pushAll() {
+      return { ok: false, status: null };
+    },
+  };
+}
+
+/**
+ * Build a key-addressed authority around an existing persistence seam.
+ *
+ * @param {Object} deps
+ * @param {import('./adapters/browserStorage').StorageAdapter} deps.storage
+ * @param {import('./adapters/serverTransport').TransportAdapter} deps.transport
+ * @param {(msg: string) => void} [deps.notify] - surfaced on quota failure
+ * @returns {{
+ *   persistence: ReturnType<typeof createPersistence>,
+ *   readByKey: (key: string, fallback?: unknown) => unknown,
+ *   writeByKey: (key: string, value: unknown) => Promise<{ok: boolean, reason?: string}>,
+ *   removeByKey: (key: string) => Promise<{ok: boolean}>,
+ * }}
+ */
+export function createAuthority({ storage, transport, notify = defaultNotify }) {
+  const persistence = createPersistence({ storage, transport });
+
+  /** Read a durable section by its localStorage key, degrading to `fallback`. */
+  function readByKey(key, fallback = null) {
+    const section = getSectionByKey(key);
+    if (!section) return fallback;
+    return persistence.read(section.id);
+  }
+
+  /**
+   * Write a durable section by its localStorage key. Commits locally first,
+   * then triggers background replication. Surfaces the quota alert to preserve
+   * the legacy `writeLS` outcome.
+   */
+  function writeByKey(key, value) {
+    const section = getSectionByKey(key);
+    if (!section) return Promise.resolve({ ok: false, reason: 'unknown-key' });
+    const result = persistence.write(section.id, value);
+    return result.then((res) => {
+      if (res && res.ok === false && res.reason === 'quota') {
+        notify(QUOTA_ALERT_MESSAGE);
+      }
+      return res;
+    });
+  }
+
+  /** Remove a durable section by its localStorage key, pushing a null deletion. */
+  function removeByKey(key) {
+    const section = getSectionByKey(key);
+    if (!section) return Promise.resolve({ ok: false, reason: 'unknown-key' });
+    return persistence.remove(section.id);
+  }
+
+  return { persistence, readByKey, writeByKey, removeByKey };
+}
+
+/** Best-effort user alert; a no-op where `alert` is unavailable (SSR/tests). */
+function defaultNotify(message) {
+  if (typeof alert === 'function') {
+    try {
+      alert(message);
+    } catch {
+      /* alert unavailable — swallow */
+    }
+  }
+}
+
+let singleton = null;
+
+/** Lazily construct the production authority (localStorage + shared sync push). */
+function getAuthority() {
+  if (!singleton) {
+    singleton = createAuthority({
+      storage: createBrowserStorageAdapter(),
+      transport: createSyncTransportAdapter(),
+    });
+  }
+  return singleton;
+}
+
+/** Read a durable section by its localStorage key (production singleton). */
+export function readByKey(key, fallback = null) {
+  return getAuthority().readByKey(key, fallback);
+}
+
+/** Write a durable section by its localStorage key (production singleton). */
+export function writeByKey(key, value) {
+  return getAuthority().writeByKey(key, value);
+}
+
+/** Remove a durable section by its localStorage key (production singleton). */
+export function removeByKey(key) {
+  return getAuthority().removeByKey(key);
+}

--- a/src/storage/authority.test.js
+++ b/src/storage/authority.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { createAuthority } from './authority';
+import { createMemoryStorageAdapter } from './adapters/browserStorage';
+import {
+  LS_WORKOUTS,
+  LS_TEMPLATES,
+  LS_SCHEDULE,
+  LS_WORKOUT_LOGS,
+  LS_ACTIVE_SESSION,
+  LS_YOUTUBE_LINKS,
+} from '../constants';
+
+function setup(opts = {}) {
+  const storage = createMemoryStorageAdapter(opts.storage);
+  const pushes = [];
+  const transport = {
+    async pullAll() {
+      return { ok: false, sections: {} };
+    },
+    async push(key, data) {
+      // Capture what storage held at the moment the push fired, so tests can
+      // assert the local commit already happened before network work started.
+      pushes.push({ key, data, committed: storage.getItem(key) });
+      return { ok: true, status: 200 };
+    },
+    async pushAll() {
+      return { ok: false, status: null };
+    },
+  };
+  const authority = createAuthority({ storage, transport });
+  return { storage, transport, pushes, authority };
+}
+
+describe('persistence authority — key-based reads', () => {
+  it('returns the section default for an empty synced key', () => {
+    const { authority } = setup();
+    expect(authority.readByKey(LS_WORKOUTS)).toEqual({});
+  });
+
+  it('returns null default for the recovery session key', () => {
+    const { authority } = setup();
+    expect(authority.readByKey(LS_ACTIVE_SESSION)).toBeNull();
+  });
+
+  it('parses and returns stored JSON for a known key', () => {
+    const { authority } = setup({ storage: { initial: { [LS_TEMPLATES]: '{"t1":{"id":"t1"}}' } } });
+    expect(authority.readByKey(LS_TEMPLATES)).toEqual({ t1: { id: 't1' } });
+  });
+
+  it('recovers from malformed stored data by returning the section default', () => {
+    const { authority } = setup({ storage: { initial: { [LS_SCHEDULE]: '{not json' } } });
+    expect(authority.readByKey(LS_SCHEDULE)).toEqual({});
+  });
+
+  it('falls back to the caller default for an unregistered key', () => {
+    const { authority } = setup();
+    expect(authority.readByKey('th_unknown', { fallback: true })).toEqual({ fallback: true });
+  });
+});
+
+describe('persistence authority — key-based writes', () => {
+  it('commits to storage before any network work and preserves the JSON shape', async () => {
+    const { authority, storage, pushes } = setup();
+    const value = { a: 1 };
+    const res = await authority.writeByKey(LS_WORKOUTS, value);
+    expect(res.ok).toBe(true);
+    // The stored JSON shape is exactly what a legacy writeLS would have stored.
+    expect(storage.getItem(LS_WORKOUTS)).toBe('{"a":1}');
+    // Replication fired for this key, and the local commit was already durable
+    // (committed === the serialized value) when the push started.
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0].key).toBe(LS_WORKOUTS);
+    expect(pushes[0].data).toEqual(value);
+    expect(pushes[0].committed).toBe('{"a":1}');
+  });
+
+  it('routes synced writes through the shared push path for background replication', async () => {
+    const { authority, pushes } = setup();
+    await authority.writeByKey(LS_WORKOUT_LOGS, { 'd::W': { completedAt: 'x' } });
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0].key).toBe(LS_WORKOUT_LOGS);
+  });
+
+  it('returns a structured quota failure and leaves storage untouched', async () => {
+    const { authority, storage } = setup({ storage: { quotaBytes: 4 } });
+    const res = await authority.writeByKey(LS_YOUTUBE_LINKS, { 'Bench Press': 'https://example.com/x' });
+    expect(res.ok).toBe(false);
+    expect(res.reason).toBe('quota');
+    expect(storage.getItem(LS_YOUTUBE_LINKS)).toBeNull();
+  });
+});
+
+describe('persistence authority — key-based removes', () => {
+  it('removes locally then pushes a null deletion for synced sections', async () => {
+    const { authority, storage, pushes } = setup({
+      storage: { initial: { [LS_ACTIVE_SESSION]: '{"logKey":"x"}' } },
+    });
+    const res = await authority.removeByKey(LS_ACTIVE_SESSION);
+    expect(res.ok).toBe(true);
+    expect(storage.getItem(LS_ACTIVE_SESSION)).toBeNull();
+    expect(pushes).toHaveLength(1);
+    expect(pushes[0].key).toBe(LS_ACTIVE_SESSION);
+    expect(pushes[0].data).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Routes TrainLog's local-first data path through the offline-persistence authority (the seam added in #51/#69) instead of the legacy `readLS`/`writeLS`/`removeLS` wrappers.

The six durable data hooks — Templates, Workouts, Schedule, Logs, recovery Session, and YouTube links — all compose `createEntityHook`, so migrating that one factory moves every one of them onto the authority in a single, low-risk change.

## What changed

- **New `src/storage/authority.js`** — a key-addressed adapter over the persistence seam:
  - Builds a production singleton from `createBrowserStorageAdapter()` (localStorage) + a **sync-transport adapter** whose `push(key, data)` delegates to the existing debounced/retry `pushToServer` in `sync.js`. This keeps a **single** background-replication path (same 500ms debounce, same retry/backoff, same `sync-push` events the UI listens to).
  - `readByKey` / `writeByKey` / `removeByKey` translate localStorage key → registry section and call the seam. Writes commit locally first, then trigger replication; the quota-exceeded alert is preserved to match legacy `writeLS`.
  - `createAuthority({ storage, transport })` is exported for dependency-injected, adapter-backed testing.
- **`createEntityHook`** now imports from `../storage/authority` and routes all reads/writes/removes through it. The hook's public interface is unchanged.
- **Tests**: new adapter-backed `authority.test.js` (default/malformed reads, commit-before-push ordering, structured quota failure, null-deletion push); `createEntityHook.test.js` re-pointed at the authority mock; new `e2e/offline-journey.e2e.js` plans + logs a full workout with the network disabled.

## Acceptance criteria

- [x] Reads/writes for Templates, Workouts, Schedule, Logs, recovery Session, YouTube links use the persistence authority, not legacy wrappers.
- [x] Every write commits locally before network work and preserves existing storage shapes (identical `JSON.stringify` under the same LS keys).
- [x] Malformed data → section default and quota failures → structured failure + preserved alert, proven by adapter-backed tests.
- [x] A network-disabled journey proves an athlete can plan and log a Workout offline (`offline-journey.e2e.js`, chromium + mobile).
- [x] Existing background replication stays connected — the authority delegates to the same `pushToServer` debounce/retry infrastructure; `useSync` and its events are untouched.

## Decisions

- **Kept a single replication path.** The transport adapter delegates to `sync.js`'s `pushToServer` rather than issuing its own `fetch`, so the debounce/retry/`sync-push` behavior and `useSync` remain exactly as before. Using the seam's own fetch transport would have created a parallel, un-retried push path.
- **Quota alert lives in the storage layer** (`authority.js`), mirroring where legacy `writeLS` raised it — architecturally consistent, and guarded for non-browser environments.
- **Scope limited to `createEntityHook`.** Backup/restore (`backup.js`, `SettingsView`) and local-only `useSettings` are out of scope for this slice; the six named sections all flow through `createEntityHook`.
- **No new visual evidence.** This is a data-layer refactor with no user-visible change; appearance/behavior is identical. The offline e2e journey exercises the real UI to confirm parity.

## Validation

- `npm run test:unit` — 501 passed
- `npm run test:e2e` — 72 passed, 6 skipped (incl. new offline journey on chromium + mobile)
- `npm run build` — success

## Review notes

Dual-model review ran two `code-review` agents in parallel against this PR's diff:

- **gpt-5.5 (code quality & correctness)** — zero findings.
- **claude-opus-4.8 (security)** — zero findings. Confirmed: no new prototype-pollution sink (parsed value goes straight to React state; the only `deepMerge` sink is the untouched pull path), keys flow through the frozen registry allow-list (no path traversal/SSRF, pushed-key set unchanged), no secrets/PII logged, `alert()` only renders a fixed constant, no dependency changes.

Closes #52

