### PR TITLE
feat: front background replication through the persistence authority

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,8 +6,8 @@ import { useWorkoutLogs } from './hooks/useWorkoutLogs';
 import { useActiveWorkout } from './hooks/useActiveWorkout';
 import { useTemplates } from './hooks/useTemplates';
 import { useSync } from './hooks/useSync';
-import { flushPendingPushes, retryFailedPushes } from './storage/sync';
-import { removeLS, clearLS } from './storage/index';
+import { flushReplication, retryReplication, removeByKey } from './storage/authority';
+import { clearLS } from './storage/index';
 import { useToast } from './components/Toast';
 import { applyTemplateChange, applyScheduleChange, applyNoteChange, applyImport } from './orchestrator';
 import {
@@ -43,7 +43,7 @@ import { MessageSquare } from 'lucide-react';
 import './styles/App.css';
 
 // Module-level guard: once set, prevents new state writes from being
-// enqueued between flushPendingPushes() completing and the reload firing.
+// enqueued between flushReplication() completing and the reload firing.
 let syncReloadInProgress = false;
 
 async function safeFlushAndReload(sessionStorageEntries = {}) {
@@ -51,7 +51,7 @@ async function safeFlushAndReload(sessionStorageEntries = {}) {
   syncReloadInProgress = true;
   window.stop(); // abort pending async operations to prevent new writes
   Object.entries(sessionStorageEntries).forEach(([k, v]) => sessionStorage.setItem(k, v));
-  await flushPendingPushes();
+  await flushReplication();
   setTimeout(() => window.location.reload(), 0);
 }
 
@@ -120,7 +120,7 @@ export default function App() {
       if (changed) {
         await safeFlushAndReload({ syncReload: '1' });
       } else if (ok) {
-        retryFailedPushes(); // push any previously-failed keys
+        retryReplication(); // push any previously-failed keys
       }
     });
   }, []);
@@ -256,12 +256,12 @@ export default function App() {
     if (syncReloadInProgress) return;
     syncReloadInProgress = true;
     window.stop();
-    await flushPendingPushes();
+    await flushReplication();
     if (!keys) {
       await clearServer();
       clearLS();
     } else {
-      keys.forEach((k) => removeLS(k));
+      keys.forEach((k) => removeByKey(k));
     }
     sessionStorage.setItem('skipSync', '1');
     setTimeout(() => window.location.reload(), 0);

--- a/src/hooks/useSync.js
+++ b/src/hooks/useSync.js
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback } from 'react';
-import { checkServerHealth, pullFromServer, pushAllToServer, clearServerData } from '../storage/sync';
+import {
+  checkReplicationHealth,
+  pullReplication,
+  pushAllReplication,
+  clearReplication,
+} from '../storage/authority';
 import { getSyncedKeys } from '../storage/registry';
 
 // Every synced durable section, sourced from the shared section registry
@@ -17,7 +22,7 @@ export function useSync() {
 
   // Check server health on mount
   useEffect(() => {
-    checkServerHealth().then((ok) => {
+    checkReplicationHealth().then((ok) => {
       setSyncStatus(ok ? 'online' : 'offline');
     });
   }, []);
@@ -37,7 +42,7 @@ export function useSync() {
   // changed=true means local data was updated and caller should reload state
   const pullSync = useCallback(async () => {
     setSyncStatus('checking');
-    const { ok, changed } = await pullFromServer();
+    const { ok, changed } = await pullReplication();
     setSyncStatus(ok ? 'online' : 'offline');
     if (ok) setLastSynced(new Date().toISOString());
     return { ok, changed };
@@ -46,7 +51,7 @@ export function useSync() {
   // Push all local data to server
   const pushSync = useCallback(async () => {
     setSyncStatus('checking');
-    const ok = await pushAllToServer(ALL_KEYS);
+    const ok = await pushAllReplication(ALL_KEYS);
     setSyncStatus(ok ? 'online' : 'offline');
     if (ok) setLastSynced(new Date().toISOString());
     return ok;
@@ -54,7 +59,7 @@ export function useSync() {
 
   // Clear all data on server
   const clearServer = useCallback(async () => {
-    return clearServerData(ALL_KEYS);
+    return clearReplication(ALL_KEYS);
   }, []);
 
   return { syncStatus, lastSynced, pullSync, pushSync, clearServer };

--- a/src/storage/authority.js
+++ b/src/storage/authority.js
@@ -27,7 +27,15 @@
 import { createPersistence } from './persistence';
 import { createBrowserStorageAdapter } from './adapters/browserStorage';
 import { getSectionByKey } from './registry';
-import { pushToServer } from './sync';
+import {
+  pushToServer,
+  flushPendingPushes,
+  retryFailedPushes,
+  pullFromServer,
+  pushAllToServer,
+  clearServerData,
+  checkServerHealth,
+} from './sync';
 
 const QUOTA_ALERT_MESSAGE = 'Storage limit exceeded. Try clearing old workouts.';
 
@@ -143,4 +151,45 @@ export function writeByKey(key, value) {
 /** Remove a durable section by its localStorage key (production singleton). */
 export function removeByKey(key) {
   return getAuthority().removeByKey(key);
+}
+
+/* -------------------------------------------------------------------------- *
+ * Replication lifecycle facade.
+ *
+ * The authority is the single owner of background replication: it fronts the
+ * private sync engine (`storage/sync`) so no production write path imports the
+ * engine's push/retry/flush helpers directly. Each function below is a thin,
+ * behavior-preserving delegate to the engine — the debounce, retry/backoff,
+ * exhaustion, reconnect, and unload/background fallback semantics all live in
+ * the engine and are reached exclusively through these entry points.
+ * -------------------------------------------------------------------------- */
+
+/** Immediately flush all debounced pushes (call before a reload/unload). */
+export function flushReplication() {
+  return flushPendingPushes();
+}
+
+/** Re-push any previously-failed keys, preserving their stored payloads. */
+export function retryReplication() {
+  return retryFailedPushes();
+}
+
+/** Pull server data and merge it into local storage. */
+export function pullReplication() {
+  return pullFromServer();
+}
+
+/** Push every provided key to the server in one bulk request. */
+export function pushAllReplication(keys) {
+  return pushAllToServer(keys);
+}
+
+/** Clear the given keys on the server (bulk null push). */
+export function clearReplication(keys) {
+  return clearServerData(keys);
+}
+
+/** Probe whether the replication server is reachable. */
+export function checkReplicationHealth() {
+  return checkServerHealth();
 }

--- a/src/storage/authority.replication.test.js
+++ b/src/storage/authority.replication.test.js
@@ -1,0 +1,78 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The authority fronts the replication engine. These tests pin the facade to the
+// engine so callers never reach into ./sync directly. The engine is mocked so we
+// observe delegation, argument forwarding, and return-value passthrough.
+vi.mock('./sync', () => ({
+  pushToServer: vi.fn(),
+  flushPendingPushes: vi.fn(() => Promise.resolve('flushed')),
+  retryFailedPushes: vi.fn(() => Promise.resolve('retried')),
+  pullFromServer: vi.fn(() => Promise.resolve({ ok: true, changed: true })),
+  pushAllToServer: vi.fn(() => Promise.resolve(true)),
+  clearServerData: vi.fn(() => Promise.resolve(true)),
+  checkServerHealth: vi.fn(() => Promise.resolve(true)),
+}));
+
+import {
+  flushReplication,
+  retryReplication,
+  pullReplication,
+  pushAllReplication,
+  clearReplication,
+  checkReplicationHealth,
+} from './authority';
+import {
+  flushPendingPushes,
+  retryFailedPushes,
+  pullFromServer,
+  pushAllToServer,
+  clearServerData,
+  checkServerHealth,
+} from './sync';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('persistence authority — replication facade', () => {
+  it('flushReplication flushes pending pushes through the engine', async () => {
+    const result = await flushReplication();
+    expect(flushPendingPushes).toHaveBeenCalledTimes(1);
+    expect(result).toBe('flushed');
+  });
+
+  it('retryReplication retries failed pushes through the engine', async () => {
+    const result = await retryReplication();
+    expect(retryFailedPushes).toHaveBeenCalledTimes(1);
+    expect(result).toBe('retried');
+  });
+
+  it('pullReplication pulls-and-merges through the engine', async () => {
+    const result = await pullReplication();
+    expect(pullFromServer).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ ok: true, changed: true });
+  });
+
+  it('pushAllReplication forwards the key list to the engine', async () => {
+    const keys = ['th_workouts', 'th_logs'];
+    const result = await pushAllReplication(keys);
+    expect(pushAllToServer).toHaveBeenCalledTimes(1);
+    expect(pushAllToServer).toHaveBeenCalledWith(keys);
+    expect(result).toBe(true);
+  });
+
+  it('clearReplication forwards the key list to the engine', async () => {
+    const keys = ['th_workouts', 'th_logs'];
+    const result = await clearReplication(keys);
+    expect(clearServerData).toHaveBeenCalledTimes(1);
+    expect(clearServerData).toHaveBeenCalledWith(keys);
+    expect(result).toBe(true);
+  });
+
+  it('checkReplicationHealth probes server health through the engine', async () => {
+    const result = await checkReplicationHealth();
+    expect(checkServerHealth).toHaveBeenCalledTimes(1);
+    expect(result).toBe(true);
+  });
+});

--- a/src/storage/replication-ownership.test.js
+++ b/src/storage/replication-ownership.test.js
@@ -1,0 +1,81 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Criterion: "No production write path imports a legacy push, retry, or flush
+ * helper directly."
+ *
+ * The persistence authority (`src/storage/`) is the single owner of the
+ * replication engine (`src/storage/sync.js`). Any app code outside the storage
+ * layer must reach replication through the authority facade, never by importing
+ * the sync engine or its push/retry/flush helpers directly.
+ */
+
+const SRC_DIR = fileURLToPath(new URL('..', import.meta.url)); // -> src/
+
+// Legacy replication helpers that must not be imported outside the storage layer.
+const LEGACY_HELPERS = [
+  'pushToServer',
+  'pushAllToServer',
+  'flushPendingPushes',
+  'retryFailedPushes',
+  'clearServerData',
+  'hasPendingPushes',
+];
+
+function collectSourceFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...collectSourceFiles(full));
+      continue;
+    }
+    if (!/\.(js|jsx)$/.test(entry)) continue;
+    if (/\.test\.(js|jsx)$/.test(entry)) continue; // tests may import the engine
+    // The storage layer IS the persistence authority + engine — exempt.
+    if (relative(SRC_DIR, full).startsWith('storage/')) continue;
+    out.push(full);
+  }
+  return out;
+}
+
+describe('replication ownership — the authority is the single seam', () => {
+  const files = collectSourceFiles(SRC_DIR);
+
+  it('finds application source files to inspect', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('no app file imports the sync replication engine directly', () => {
+    const offenders = [];
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8');
+      // Any import from a module path ending in "/sync" (the replication engine).
+      if (/from\s+['"][^'"]*\/sync['"]/.test(src)) {
+        offenders.push(relative(SRC_DIR, file));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('no app file imports a legacy push/retry/flush helper by name', () => {
+    const offenders = [];
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8');
+      for (const helper of LEGACY_HELPERS) {
+        const importsHelper = new RegExp(
+          `import[^;]*\\b${helper}\\b[^;]*from\\s+['"][^'"]*sync['"]`,
+          's'
+        );
+        if (importsHelper.test(src)) {
+          offenders.push(`${relative(SRC_DIR, file)} -> ${helper}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});

--- a/src/storage/replication.integration.test.js
+++ b/src/storage/replication.integration.test.js
@@ -1,0 +1,135 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { LS_WORKOUTS, LS_ACTIVE_SESSION } from '../constants';
+
+// End-to-end proof that debounce, deletion, retry, and flush replication all pass
+// through the persistence authority's public API against the REAL sync engine
+// (only the network is faked). Modules are reset per test so the engine's
+// in-memory queue/retry state never leaks between scenarios. Browser globals are
+// stubbed explicitly for determinism instead of relying on a full DOM.
+
+let store = {};
+
+function makeLocalStorage() {
+  return {
+    getItem: (key) => (key in store ? store[key] : null),
+    setItem: (key, val) => { store[key] = String(val); },
+    removeItem: (key) => { delete store[key]; },
+    clear: () => { store = {}; },
+    key: (i) => Object.keys(store)[i] ?? null,
+    get length() { return Object.keys(store).length; },
+  };
+}
+
+if (!AbortSignal.timeout) {
+  AbortSignal.timeout = (ms) => {
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(), ms);
+    return controller.signal;
+  };
+}
+
+function bodyOf(call) {
+  return JSON.parse(call[1].body);
+}
+
+async function loadAuthorityWithEngine() {
+  vi.resetModules();
+  const authority = await import('./authority');
+  const sync = await import('./sync');
+  sync.setSyncEnabled(true);
+  return { authority, sync };
+}
+
+beforeEach(() => {
+  store = {};
+  vi.stubGlobal('localStorage', makeLocalStorage());
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true })));
+  vi.stubGlobal('CustomEvent', class CustomEvent {
+    constructor(type, opts) { this.type = type; this.detail = opts?.detail; }
+  });
+  vi.stubGlobal('document', { addEventListener: vi.fn(), visibilityState: 'visible' });
+  vi.stubGlobal('window', { addEventListener: vi.fn(), dispatchEvent: vi.fn() });
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('replication through the persistence authority', () => {
+  it('debounces rapid writes and replicates only the latest value', async () => {
+    const { authority } = await loadAuthorityWithEngine();
+
+    await authority.writeByKey(LS_WORKOUTS, { v: 1 });
+    await authority.writeByKey(LS_WORKOUTS, { v: 2 });
+    await authority.writeByKey(LS_WORKOUTS, { v: 3 });
+
+    // Local commit is immediate and holds the latest value.
+    expect(store[LS_WORKOUTS]).toBe('{"v":3}');
+    // No network work before the debounce elapses.
+    expect(fetch).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(bodyOf(fetch.mock.calls[0])).toEqual({ data: { v: 3 } });
+  });
+
+  it('replicates a deletion as a null push', async () => {
+    const { authority } = await loadAuthorityWithEngine();
+    store[LS_ACTIVE_SESSION] = '{"logKey":"x"}';
+
+    await authority.removeByKey(LS_ACTIVE_SESSION);
+
+    expect(store[LS_ACTIVE_SESSION]).toBeUndefined();
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const call = fetch.mock.calls[0];
+    expect(call[0]).toContain(LS_ACTIVE_SESSION);
+    expect(bodyOf(call)).toEqual({ data: null });
+  });
+
+  it('flushReplication forces a pending push without waiting for the debounce', async () => {
+    const { authority } = await loadAuthorityWithEngine();
+
+    await authority.writeByKey(LS_WORKOUTS, { flushed: true });
+    expect(fetch).not.toHaveBeenCalled();
+
+    await authority.flushReplication();
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(bodyOf(fetch.mock.calls[0])).toEqual({ data: { flushed: true } });
+  });
+
+  it('retries a failed push with backoff, preserving the exact payload', async () => {
+    const { authority } = await loadAuthorityWithEngine();
+    fetch.mockRejectedValueOnce(new Error('offline'));
+
+    await authority.writeByKey(LS_WORKOUTS, { attempt: 1 });
+    await vi.advanceTimersByTimeAsync(500); // first push fails
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1000); // backoff retry succeeds
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(bodyOf(fetch.mock.calls[1])).toEqual({ data: { attempt: 1 } });
+  });
+
+  it('retryReplication re-pushes a failed deletion payload on reconnect', async () => {
+    const { authority } = await loadAuthorityWithEngine();
+    store[LS_ACTIVE_SESSION] = '{"logKey":"x"}';
+    fetch.mockRejectedValueOnce(new Error('offline'));
+
+    await authority.removeByKey(LS_ACTIVE_SESSION);
+    await vi.advanceTimersByTimeAsync(500); // deletion push fails, payload=null retained
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    fetch.mockResolvedValueOnce({ ok: true });
+    await authority.retryReplication();
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(bodyOf(fetch.mock.calls[1])).toEqual({ data: null });
+  });
+});

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -27,9 +27,8 @@ import {
 import Modal from '../components/Modal';
 import FeedbackModal from '../components/FeedbackModal';
 import { useToast } from '../components/Toast';
-import { writeLS } from '../storage/index';
 import { buildBackup, BACKUP_KEYS } from '../storage/backup';
-import { flushPendingPushes } from '../storage/sync';
+import { writeByKey, flushReplication } from '../storage/authority';
 import {
   LS_WORKOUTS,
   LS_SCHEDULE,
@@ -222,9 +221,9 @@ export default function SettingsView({
     if (!pendingRestore) return;
     const { data, keys } = pendingRestore;
     keys.forEach((key) => {
-      writeLS(key, data[key]); // write to LS + queue sync push
+      writeByKey(key, data[key]); // commit locally + queue replication via the authority
     });
-    await flushPendingPushes(); // push to server before reload
+    await flushReplication(); // push to server before reload
     sessionStorage.setItem('skipSync', '1'); // don't let pull overwrite restored data
     setPendingRestore(null);
     showToast(`Restored ${keys.length} data section${keys.length !== 1 ? 's' : ''}!`);


### PR DESCRIPTION
## Summary

Makes the **persistence authority** (`src/storage/authority.js`) the single owner of both local persistence *and* background replication. Production write paths no longer import the sync engine's push/retry/flush helpers directly — they reach replication only through the authority facade.

Closes #53

## What changed

- **Replication facade on the authority** — adds `flushReplication`, `retryReplication`, `pullReplication`, `pushAllReplication`, `clearReplication`, and `checkReplicationHealth`, each a thin, behavior-preserving delegate to the private sync engine (`src/storage/sync.js`).
- **Consumers migrated off the engine:**
  - `App.jsx` — uses `flushReplication` / `retryReplication`; clear-all deletion now goes through the authority's `removeByKey` instead of legacy `removeLS`.
  - `views/SettingsView.jsx` — backup restore commits + replicates through `writeByKey` + `flushReplication` instead of `writeLS` + `flushPendingPushes`.
  - `hooks/useSync.js` — pull / push-all / clear / health now route through the authority facade.
- The debounce, deletion (null push), retry/backoff, exhaustion, reconnect, and unload/background flush semantics are **unchanged** — only the ownership seam moved. `sync.js` is now imported for replication solely by the authority.

## Acceptance criteria

- [x] Rapid changes commit locally first and replicate only the latest value after the debounce — proven by `replication.integration.test.js`.
- [x] Failed pushes retain their exact payload (incl. deletions) and preserve backoff/exhaustion/reconnect — engine unchanged; covered by integration retry + reconnect tests.
- [x] Pending replication flushes on backgrounding/unload with the existing `sendBeacon` fallback — engine lifecycle listeners unchanged.
- [x] No production write path imports a legacy push/retry/flush helper directly — enforced by `replication-ownership.test.js`.
- [x] Debounce, retry, deletion, reconnect, and flush scenarios pass through the persistence authority — `replication.integration.test.js`.

## Tests added

- `src/storage/authority.replication.test.js` — facade delegates to the engine (args + return passthrough).
- `src/storage/replication.integration.test.js` — debounce / deletion / retry / flush / reconnect driven through the authority public API against the real engine (network faked).
- `src/storage/replication-ownership.test.js` — guard: no file outside `src/storage/` imports the sync engine or its push/retry/flush helpers.

## Validation

- `npm run test:unit` — 515 passed
- `npm run test:e2e` — 72 passed, 6 skipped
- `npm run build` — success

## Decisions

- **Kept the delicate lifecycle mechanics in `sync.js`** (visibilitychange/beforeunload/online listeners, `sendBeacon` fallback, retry backoff/exhaustion) rather than relocating them into the authority. Those touch module-private queue/retry state, and the criteria emphasize *preserving* fallback/backoff/reconnect behavior. The authority fronts the engine as the single public owner; the engine's internal auto-triggers remain the same code path reached through that owner.
- **Left read-only `readLS`/`clearLS` imports from `storage/index`** in place (they are not push/retry/flush helpers and don't participate in replication ownership).

## Review notes

Dual-model code review run against this PR:
- **Code quality & correctness (gpt-5.6-sol):** No significant issues found. The async `writeByKey`/`removeByKey` migration was traced — `transport.push` (and thus `pushToServer`'s debounce timer) fires synchronously before the first `await`, so `flushReplication()` still picks up all queued pushes in the clear-all and restore paths.
- **Security (claude-opus-4.8):** No vulnerabilities introduced. Backup-restore keys stay constrained to the `BACKUP_KEYS` registry allowlist and are re-validated by `getSectionByKey`, so no arbitrary localStorage key or `/api/data/${key}` request path is constructable from a crafted backup file. The `removeLS`→`removeByKey` swap is a validation *gain* (rejects non-registry keys). No new prototype-pollution sink, no secrets.

## Visual verification

No user-visible/UI change — this is an internal persistence-layer refactor. The `@visual` e2e journeys (settings clear-data, workout flow, restore paths) all pass unchanged, so no new screenshot evidence was generated.

