### PR TITLE
feat: pull data safely and coordinate one sync reload

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ import { useWorkoutLogs } from './hooks/useWorkoutLogs';
 import { useActiveWorkout } from './hooks/useActiveWorkout';
 import { useTemplates } from './hooks/useTemplates';
 import { useSync } from './hooks/useSync';
-import { flushReplication, retryReplication, removeByKey } from './storage/authority';
+import { retryReplication, removeByKey, coordinateSyncReload } from './storage/authority';
 import { clearLS } from './storage/index';
 import { useToast } from './components/Toast';
 import { applyTemplateChange, applyScheduleChange, applyNoteChange, applyImport } from './orchestrator';
@@ -42,17 +42,10 @@ import { MessageSquare } from 'lucide-react';
 
 import './styles/App.css';
 
-// Module-level guard: once set, prevents new state writes from being
-// enqueued between flushReplication() completing and the reload firing.
-let syncReloadInProgress = false;
-
+// The persistence authority owns the exactly-once, reload-safe sequence
+// (final flush → skip-next-pull → single reload); App just names the flow.
 async function safeFlushAndReload(sessionStorageEntries = {}) {
-  if (syncReloadInProgress) return;
-  syncReloadInProgress = true;
-  window.stop(); // abort pending async operations to prevent new writes
-  Object.entries(sessionStorageEntries).forEach(([k, v]) => sessionStorage.setItem(k, v));
-  await flushReplication();
-  setTimeout(() => window.location.reload(), 0);
+  await coordinateSyncReload({ sessionFlags: sessionStorageEntries });
 }
 
 export default function App() {
@@ -253,18 +246,16 @@ export default function App() {
 
   // Shared clear-all handler (used by SettingsView in two routes)
   const handleClearAllData = useCallback(async (keys) => {
-    if (syncReloadInProgress) return;
-    syncReloadInProgress = true;
-    window.stop();
-    await flushReplication();
-    if (!keys) {
-      await clearServer();
-      clearLS();
-    } else {
-      keys.forEach((k) => removeByKey(k));
-    }
-    sessionStorage.setItem('skipSync', '1');
-    setTimeout(() => window.location.reload(), 0);
+    await coordinateSyncReload({
+      mutate: async () => {
+        if (!keys) {
+          await clearServer();
+          clearLS();
+        } else {
+          keys.forEach((k) => removeByKey(k));
+        }
+      },
+    });
   }, [clearServer]);
 
   const handlePullSync = useCallback(async () => {

--- a/src/storage/authority.js
+++ b/src/storage/authority.js
@@ -193,3 +193,72 @@ export function clearReplication(keys) {
 export function checkReplicationHealth() {
   return checkServerHealth();
 }
+
+/* -------------------------------------------------------------------------- *
+ * Reload coordination.
+ *
+ * A handful of flows (a sync merge that changed local data, a clear-all, a
+ * backup restore) must commit their changes, force any pending replication to
+ * the server, and then reload the page. Left uncoordinated they race: a second
+ * trigger could reload twice, or a state write could slip in between the final
+ * flush and the reload and be lost.
+ *
+ * `coordinateSyncReload` is the single owner of that sequence. It runs exactly
+ * once per page life, aborts in-flight async work first (so nothing new can
+ * enqueue), runs an optional caller mutation, performs the FINAL flush, marks
+ * the next startup pull to be skipped, then schedules one reload.
+ * -------------------------------------------------------------------------- */
+
+let reloadInProgress = false;
+
+/**
+ * Coordinate the one-and-only sync reload for this page.
+ *
+ * Sequence (exactly once): abort in-flight work → optional `mutate` →
+ * final flush → set `skipSync` (+ caller flags) → schedule a single reload.
+ *
+ * @param {Object} [opts]
+ * @param {() => (void | Promise<void>)} [opts.mutate] - data change to commit under the guard
+ * @param {Record<string, string>} [opts.sessionFlags] - extra sessionStorage flags to set
+ * @param {number} [opts.delayMs=0] - delay before the reload (e.g. to show a toast)
+ * @returns {Promise<boolean>} true if this call owned the reload, false if one was already in progress
+ */
+export async function coordinateSyncReload({ mutate, sessionFlags = {}, delayMs = 0 } = {}) {
+  if (reloadInProgress) return false;
+  reloadInProgress = true;
+
+  // Abort pending async operations so no new local write can enqueue between
+  // the final flush and the reload.
+  if (typeof window !== 'undefined' && typeof window.stop === 'function') {
+    try {
+      window.stop();
+    } catch {
+      /* window.stop unavailable — ignore */
+    }
+  }
+
+  if (typeof mutate === 'function') {
+    await mutate();
+  }
+
+  // The final flush: everything committed above reaches the server before reload.
+  await flushReplication();
+
+  if (typeof sessionStorage !== 'undefined') {
+    // Skip the next startup pull so we don't re-merge what we just reconciled.
+    sessionStorage.setItem('skipSync', '1');
+    for (const [key, value] of Object.entries(sessionFlags)) {
+      sessionStorage.setItem(key, value);
+    }
+  }
+
+  if (typeof window !== 'undefined' && window.location && typeof window.location.reload === 'function') {
+    setTimeout(() => window.location.reload(), delayMs);
+  }
+  return true;
+}
+
+/** Test-only: reset the exactly-once reload guard between cases. */
+export function __resetSyncReload() {
+  reloadInProgress = false;
+}

--- a/src/storage/authority.reload.test.js
+++ b/src/storage/authority.reload.test.js
@@ -1,0 +1,101 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// The authority owns the single reload-safe path used after a sync merge, a
+// clear-all, or a backup restore. The replication engine is mocked so we observe
+// the coordinator's ordering and exactly-once guarantees without real I/O.
+const order = [];
+
+vi.mock('./sync', () => ({
+  pushToServer: vi.fn(),
+  flushPendingPushes: vi.fn(() => { order.push('flush'); return Promise.resolve(); }),
+  retryFailedPushes: vi.fn(() => Promise.resolve()),
+  pullFromServer: vi.fn(() => Promise.resolve({ ok: true, changed: false })),
+  pushAllToServer: vi.fn(() => Promise.resolve(true)),
+  clearServerData: vi.fn(() => Promise.resolve(true)),
+  checkServerHealth: vi.fn(() => Promise.resolve(true)),
+}));
+
+import { coordinateSyncReload, __resetSyncReload } from './authority';
+import { flushPendingPushes } from './sync';
+
+let sessionFlags;
+let reloadCalls;
+let stopCalls;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  order.length = 0;
+  sessionFlags = {};
+  reloadCalls = 0;
+  stopCalls = 0;
+  __resetSyncReload();
+  vi.useFakeTimers();
+  vi.stubGlobal('sessionStorage', {
+    setItem: (k, v) => { sessionFlags[k] = v; },
+    getItem: (k) => (k in sessionFlags ? sessionFlags[k] : null),
+    removeItem: (k) => { delete sessionFlags[k]; },
+  });
+  vi.stubGlobal('window', {
+    stop: () => { order.push('stop'); stopCalls += 1; },
+    location: { reload: () => { reloadCalls += 1; } },
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('authority — coordinateSyncReload', () => {
+  it('flushes then reloads exactly once, setting skipSync (skip-next-pull)', async () => {
+    const started = await coordinateSyncReload();
+    expect(started).toBe(true);
+
+    expect(flushPendingPushes).toHaveBeenCalledTimes(1);
+    expect(sessionFlags.skipSync).toBe('1');
+
+    // Reload is scheduled, not fired synchronously; it fires once when timers run.
+    expect(reloadCalls).toBe(0);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(reloadCalls).toBe(1);
+  });
+
+  it('aborts in-flight work with window.stop() before the final flush', async () => {
+    await coordinateSyncReload();
+    expect(stopCalls).toBe(1);
+    // stop must precede the flush so no new write can enqueue in between.
+    expect(order.indexOf('stop')).toBeLessThan(order.indexOf('flush'));
+  });
+
+  it('runs the mutate hook before the final flush', async () => {
+    const mutate = vi.fn(() => { order.push('mutate'); });
+    await coordinateSyncReload({ mutate });
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['stop', 'mutate', 'flush']);
+  });
+
+  it('merges caller session flags alongside skipSync', async () => {
+    await coordinateSyncReload({ sessionFlags: { syncReload: '1' } });
+    expect(sessionFlags.skipSync).toBe('1');
+    expect(sessionFlags.syncReload).toBe('1');
+  });
+
+  it('is exactly-once: a second call is a no-op that never double-reloads', async () => {
+    await coordinateSyncReload();
+    const second = await coordinateSyncReload({ mutate: vi.fn() });
+
+    expect(second).toBe(false);
+    expect(flushPendingPushes).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(600);
+    expect(reloadCalls).toBe(1);
+  });
+
+  it('honors a delay before reloading (for toast visibility)', async () => {
+    await coordinateSyncReload({ delayMs: 500 });
+    await vi.advanceTimersByTimeAsync(400);
+    expect(reloadCalls).toBe(0);
+    await vi.advanceTimersByTimeAsync(100);
+    expect(reloadCalls).toBe(1);
+  });
+});

--- a/src/storage/merge.js
+++ b/src/storage/merge.js
@@ -22,3 +22,65 @@ export function deepMerge(local, server) {
   }
   return merged;
 }
+
+/**
+ * Decide how one server section should reconcile with local storage, without
+ * performing any I/O. Pure so the pull policy can be tested in isolation and so
+ * a single malformed section can be skipped by the caller without aborting the
+ * rest of the pull.
+ *
+ * Map data stays server-wins on conflicts while local-only entries survive
+ * (via {@link deepMerge}); arrays/primitives are overwritten by the server.
+ * A `data: null` entry is disambiguated by `updatedAt`:
+ *   - `updatedAt == null` → the server has never stored this section, so local
+ *     data is pushed up (returned as an `push` action) instead of being lost.
+ *   - `updatedAt` set      → an intentional deletion, so local is removed.
+ * Malformed local content is treated as absent (the server value wins).
+ *
+ * @param {string|null|undefined} localRaw - the raw localStorage string for the key
+ * @param {{ data: unknown, updatedAt: string|null }} serverEntry
+ * @returns {{ action: 'write', value: unknown, serialized: string }
+ *          | { action: 'push', value: unknown }
+ *          | { action: 'remove' }
+ *          | { action: 'none' }}
+ */
+export function planSectionMerge(localRaw, serverEntry) {
+  const { data, updatedAt } = serverEntry;
+
+  let local = null;
+  if (localRaw !== null && localRaw !== undefined) {
+    try {
+      local = JSON.parse(localRaw);
+    } catch {
+      // Malformed local content — treat as absent so the server value wins.
+      local = null;
+    }
+  }
+
+  if (data === null || data === undefined) {
+    if (updatedAt === null || updatedAt === undefined) {
+      // Server has no file yet — push local up so offline writes aren't lost.
+      return local !== null ? { action: 'push', value: local } : { action: 'none' };
+    }
+    // Intentional deletion — remove local key if present.
+    return local !== null ? { action: 'remove' } : { action: 'none' };
+  }
+
+  let merged;
+  if (
+    local !== null &&
+    typeof local === 'object' && !Array.isArray(local) &&
+    typeof data === 'object' && !Array.isArray(data)
+  ) {
+    // Merge maps: deep merge preserves local-only nested fields, server wins at leaf.
+    merged = deepMerge(local, data);
+  } else {
+    merged = data;
+  }
+
+  const serialized = JSON.stringify(merged);
+  if (serialized !== localRaw) {
+    return { action: 'write', value: merged, serialized };
+  }
+  return { action: 'none' };
+}

--- a/src/storage/merge.js
+++ b/src/storage/merge.js
@@ -43,9 +43,21 @@ export function deepMerge(local, server) {
  *          | { action: 'push', value: unknown }
  *          | { action: 'remove' }
  *          | { action: 'none' }}
+ * @throws {TypeError} when `serverEntry` is malformed (not an object, or missing
+ *   its `data` field) so the caller can skip the section without touching local data.
  */
 export function planSectionMerge(localRaw, serverEntry) {
+  if (
+    serverEntry === null || typeof serverEntry !== 'object' || Array.isArray(serverEntry)
+  ) {
+    throw new TypeError('planSectionMerge: malformed server entry (not an object)');
+  }
   const { data, updatedAt } = serverEntry;
+  // A well-formed entry always carries a `data` key (possibly null). Missing or
+  // undefined `data` is malformed — never interpret it as a deletion/push.
+  if (data === undefined) {
+    throw new TypeError('planSectionMerge: malformed server entry (missing "data")');
+  }
 
   let local = null;
   if (localRaw !== null && localRaw !== undefined) {
@@ -57,7 +69,7 @@ export function planSectionMerge(localRaw, serverEntry) {
     }
   }
 
-  if (data === null || data === undefined) {
+  if (data === null) {
     if (updatedAt === null || updatedAt === undefined) {
       // Server has no file yet — push local up so offline writes aren't lost.
       return local !== null ? { action: 'push', value: local } : { action: 'none' };

--- a/src/storage/merge.test.js
+++ b/src/storage/merge.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { deepMerge } from './merge.js';
+import { deepMerge, planSectionMerge } from './merge.js';
 
 describe('deepMerge', () => {
   it('returns server when both are flat objects (server wins)', () => {
@@ -61,5 +61,59 @@ describe('deepMerge', () => {
     const result = deepMerge(local, server);
     expect(result.a).toBe(2);
     expect(({}).polluted).toBeUndefined();
+  });
+});
+
+describe('planSectionMerge', () => {
+  it('writes server data when local is absent', () => {
+    const plan = planSectionMerge(null, { data: { 'Upper A': { title: 'Upper A' } }, updatedAt: '2024-01-01' });
+    expect(plan.action).toBe('write');
+    expect(plan.value).toEqual({ 'Upper A': { title: 'Upper A' } });
+    expect(plan.serialized).toBe(JSON.stringify({ 'Upper A': { title: 'Upper A' } }));
+  });
+
+  it('is a no-op when merged data equals the stored raw string', () => {
+    const data = { 'Upper A': { title: 'Upper A' } };
+    const raw = JSON.stringify(data);
+    expect(planSectionMerge(raw, { data, updatedAt: '2024-01-01' })).toEqual({ action: 'none' });
+  });
+
+  it('merges maps: server wins on conflict, local-only entries preserved', () => {
+    const local = { exercise1: { reps: 10 }, exercise2: { reps: 5 } };
+    const server = { exercise1: { reps: 12 }, exercise3: { reps: 8 } };
+    const plan = planSectionMerge(JSON.stringify(local), { data: server, updatedAt: '2024-01-01' });
+    expect(plan.action).toBe('write');
+    expect(plan.value).toEqual({ exercise1: { reps: 12 }, exercise2: { reps: 5 }, exercise3: { reps: 8 } });
+  });
+
+  it('overwrites with server data for arrays (no merge)', () => {
+    const plan = planSectionMerge(JSON.stringify(['old1']), { data: ['item1', 'item2'], updatedAt: '2024-01-01' });
+    expect(plan.action).toBe('write');
+    expect(plan.value).toEqual(['item1', 'item2']);
+  });
+
+  it('pushes local up when server never populated (data null, updatedAt null)', () => {
+    const local = { 'Upper A': { title: 'Upper A' } };
+    const plan = planSectionMerge(JSON.stringify(local), { data: null, updatedAt: null });
+    expect(plan).toEqual({ action: 'push', value: local });
+  });
+
+  it('does nothing when server never populated and local is absent', () => {
+    expect(planSectionMerge(null, { data: null, updatedAt: null })).toEqual({ action: 'none' });
+  });
+
+  it('removes local on an intentional server deletion (data null, updatedAt set)', () => {
+    const plan = planSectionMerge(JSON.stringify({ some: 'data' }), { data: null, updatedAt: '2024-06-15T00:00:00Z' });
+    expect(plan).toEqual({ action: 'remove' });
+  });
+
+  it('does nothing when server deleted a key local no longer has', () => {
+    expect(planSectionMerge(null, { data: null, updatedAt: '2024-06-15T00:00:00Z' })).toEqual({ action: 'none' });
+  });
+
+  it('treats malformed local data as absent and takes the server value', () => {
+    const plan = planSectionMerge('{not-json', { data: { a: 1 }, updatedAt: '2024-01-01' });
+    expect(plan.action).toBe('write');
+    expect(plan.value).toEqual({ a: 1 });
   });
 });

--- a/src/storage/merge.test.js
+++ b/src/storage/merge.test.js
@@ -116,4 +116,20 @@ describe('planSectionMerge', () => {
     expect(plan.action).toBe('write');
     expect(plan.value).toEqual({ a: 1 });
   });
+
+  it('throws for an entry missing the data field so the caller skips it (no deletion)', () => {
+    // A well-formed server entry always carries a `data` key (possibly null); a
+    // missing `data` is malformed and must not be read as an intentional deletion.
+    expect(() => planSectionMerge(JSON.stringify({ keep: 1 }), { updatedAt: '2024-01-01' })).toThrow();
+  });
+
+  it('throws for an entry with explicitly undefined data', () => {
+    expect(() => planSectionMerge(null, { data: undefined, updatedAt: null })).toThrow();
+  });
+
+  it('throws for a non-object server entry', () => {
+    expect(() => planSectionMerge(null, 42)).toThrow();
+    expect(() => planSectionMerge(null, null)).toThrow();
+    expect(() => planSectionMerge(null, [1, 2])).toThrow();
+  });
 });

--- a/src/storage/sync.js
+++ b/src/storage/sync.js
@@ -8,7 +8,7 @@
  */
 
 import { readLS, writeLS, removeLS } from './index';
-import { deepMerge } from './merge';
+import { planSectionMerge } from './merge';
 import { createRetryState, recordFailure, dropKey, getFailedEntries, shouldRetry, getBackoffMs } from './retry';
 
 // API base URL — in production, same origin; in dev, point to backend port
@@ -71,56 +71,39 @@ export async function pullFromServer() {
 
     let changed = false;
     const changedKeys = [];
-    for (const [key, { data, updatedAt }] of Object.entries(serverData)) {
-      // Read the raw stored string once — used for efficient change detection
-      // below (avoids re-serializing local and sidesteps key-order false positives)
-      const localRaw = localStorage.getItem(key);
-      let local = null;
-      if (localRaw) {
-        try {
-          local = JSON.parse(localRaw);
-        } catch (e) {
-          console.warn(`Ignoring malformed localStorage value for key "${key}" during sync pull`, e);
-          local = null;
-        }
-      }
+    for (const [key, entry] of Object.entries(serverData)) {
+      // Isolate every section: a malformed or unprocessable entry is skipped so
+      // it can never prevent the remaining sections from syncing.
+      try {
+        // Read the raw stored string once — used for efficient change detection
+        // inside planSectionMerge (avoids re-serializing local and sidesteps
+        // key-order false positives).
+        const localRaw = localStorage.getItem(key);
+        const plan = planSectionMerge(localRaw, entry);
 
-      if (data === null) {
-        if (updatedAt === null) {
-          // Server has no file yet — push local data up so offline writes aren't lost
-          if (local !== null) {
-            pushToServer(key, local);
-          }
-        } else {
-          // Intentional deletion — remove local key if present
-          if (local !== null) {
+        switch (plan.action) {
+          case 'push':
+            // Server has no file yet — push local data up so offline writes aren't lost.
+            pushToServer(key, plan.value);
+            break;
+          case 'remove':
+            // Intentional deletion — remove local key if present.
             removeLS(key);
             changed = true;
             changedKeys.push(key);
-          }
+            break;
+          case 'write':
+            // Write directly to localStorage (bypassing writeLS) so we don't
+            // enqueue a redundant push back to the server for data we just pulled.
+            localStorage.setItem(key, plan.serialized);
+            changed = true;
+            changedKeys.push(key);
+            break;
+          default:
+            break;
         }
-        continue;
-      }
-
-      let merged;
-      if (
-        local !== null &&
-        typeof local === 'object' && !Array.isArray(local) &&
-        typeof data === 'object' && !Array.isArray(data)
-      ) {
-        // Merge maps: deep merge preserves local-only nested fields, server wins at leaf
-        merged = deepMerge(local, data);
-      } else {
-        merged = data;
-      }
-      // One stringify (merged) compared against the already-stored raw string.
-      // Write directly to localStorage (bypassing writeLS) so we don't enqueue
-      // a redundant push back to the server for data we just pulled from it.
-      const mergedStr = JSON.stringify(merged);
-      if (mergedStr !== localRaw) {
-        localStorage.setItem(key, mergedStr);
-        changed = true;
-        changedKeys.push(key);
+      } catch (e) {
+        console.warn(`Ignoring malformed server section "${key}" during sync pull`, e);
       }
     }
     if (changed) {

--- a/src/storage/sync.js
+++ b/src/storage/sync.js
@@ -72,38 +72,42 @@ export async function pullFromServer() {
     let changed = false;
     const changedKeys = [];
     for (const [key, entry] of Object.entries(serverData)) {
-      // Isolate every section: a malformed or unprocessable entry is skipped so
-      // it can never prevent the remaining sections from syncing.
+      // Isolate malformed server sections: a section whose entry can't be planned
+      // is skipped so it can never prevent the remaining sections from syncing.
+      // Local persistence errors (below) are NOT swallowed here — they are real
+      // pull failures and propagate to the outer catch as { ok: false }.
+      let plan;
       try {
         // Read the raw stored string once — used for efficient change detection
         // inside planSectionMerge (avoids re-serializing local and sidesteps
         // key-order false positives).
         const localRaw = localStorage.getItem(key);
-        const plan = planSectionMerge(localRaw, entry);
-
-        switch (plan.action) {
-          case 'push':
-            // Server has no file yet — push local data up so offline writes aren't lost.
-            pushToServer(key, plan.value);
-            break;
-          case 'remove':
-            // Intentional deletion — remove local key if present.
-            removeLS(key);
-            changed = true;
-            changedKeys.push(key);
-            break;
-          case 'write':
-            // Write directly to localStorage (bypassing writeLS) so we don't
-            // enqueue a redundant push back to the server for data we just pulled.
-            localStorage.setItem(key, plan.serialized);
-            changed = true;
-            changedKeys.push(key);
-            break;
-          default:
-            break;
-        }
+        plan = planSectionMerge(localRaw, entry);
       } catch (e) {
         console.warn(`Ignoring malformed server section "${key}" during sync pull`, e);
+        continue;
+      }
+
+      switch (plan.action) {
+        case 'push':
+          // Server has no file yet — push local data up so offline writes aren't lost.
+          pushToServer(key, plan.value);
+          break;
+        case 'remove':
+          // Intentional deletion — remove local key if present.
+          removeLS(key);
+          changed = true;
+          changedKeys.push(key);
+          break;
+        case 'write':
+          // Write directly to localStorage (bypassing writeLS) so we don't enqueue
+          // a redundant push back to the server for data we just pulled.
+          localStorage.setItem(key, plan.serialized);
+          changed = true;
+          changedKeys.push(key);
+          break;
+        default:
+          break;
       }
     }
     if (changed) {

--- a/src/storage/sync.test.js
+++ b/src/storage/sync.test.js
@@ -264,6 +264,30 @@ describe('sync.js', () => {
         JSON.stringify({ '2024-01-01': 'Upper A' })
       );
     });
+
+    it('skips a section whose server entry is missing data (never deletes local)', async () => {
+      // A malformed entry lacking `data` must not be read as an intentional deletion.
+      mockFetchJson({ th_workouts: { updatedAt: '2024-01-01' } });
+      localStorage.getItem.mockReturnValue(JSON.stringify({ keep: 1 }));
+
+      const result = await pullFromServer();
+
+      expect(result).toEqual({ ok: true, changed: false });
+      expect(removeLS).not.toHaveBeenCalled();
+      expect(localStorage.setItem).not.toHaveBeenCalled();
+    });
+
+    it('returns ok=false when persisting a valid server section fails locally (quota)', async () => {
+      // A local write failure is a real pull failure, not a malformed server section:
+      // it must surface as ok:false rather than being silently swallowed.
+      mockFetchJson({ th_workouts: { data: { a: 1 }, updatedAt: '2024-01-01' } });
+      localStorage.getItem.mockReturnValue(null);
+      localStorage.setItem.mockImplementationOnce(() => { throw new Error('QuotaExceededError'); });
+
+      const result = await pullFromServer();
+
+      expect(result).toEqual({ ok: false, changed: false });
+    });
   });
 
   // =========================================================================

--- a/src/storage/sync.test.js
+++ b/src/storage/sync.test.js
@@ -225,6 +225,45 @@ describe('sync.js', () => {
       expect(result).toEqual({ ok: false, changed: false });
       expect(writeLS).not.toHaveBeenCalled();
     });
+
+    it('isolates a malformed server section so other sections still sync', async () => {
+      // th_bad is unprocessable (null entry — destructuring { data, updatedAt } throws);
+      // th_workouts is a valid section that must still be written.
+      mockFetchJson({
+        th_bad: null,
+        th_workouts: { data: { 'Upper A': { title: 'Upper A' } }, updatedAt: '2024-01-01' },
+      });
+      localStorage.getItem.mockReturnValue(null);
+
+      const result = await pullFromServer();
+
+      // The pull as a whole succeeds and reports the good section as changed.
+      expect(result).toEqual({ ok: true, changed: true });
+      // The good section was written despite the malformed sibling.
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'th_workouts',
+        JSON.stringify({ 'Upper A': { title: 'Upper A' } })
+      );
+    });
+
+    it('does not abort the pull when one section throws mid-loop', async () => {
+      // Two malformed sections surround a valid one; only the valid one is applied.
+      mockFetchJson({
+        th_bad1: null,
+        th_schedule: { data: { '2024-01-01': 'Upper A' }, updatedAt: '2024-01-01' },
+        th_bad2: 42,
+      });
+      localStorage.getItem.mockReturnValue(null);
+
+      const result = await pullFromServer();
+
+      expect(result.ok).toBe(true);
+      expect(result.changed).toBe(true);
+      expect(localStorage.setItem).toHaveBeenCalledWith(
+        'th_schedule',
+        JSON.stringify({ '2024-01-01': 'Upper A' })
+      );
+    });
   });
 
   // =========================================================================

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -28,7 +28,7 @@ import Modal from '../components/Modal';
 import FeedbackModal from '../components/FeedbackModal';
 import { useToast } from '../components/Toast';
 import { buildBackup, BACKUP_KEYS } from '../storage/backup';
-import { writeByKey, flushReplication } from '../storage/authority';
+import { writeByKey, coordinateSyncReload } from '../storage/authority';
 import {
   LS_WORKOUTS,
   LS_SCHEDULE,
@@ -220,14 +220,18 @@ export default function SettingsView({
   const handleConfirmRestore = async () => {
     if (!pendingRestore) return;
     const { data, keys } = pendingRestore;
-    keys.forEach((key) => {
-      writeByKey(key, data[key]); // commit locally + queue replication via the authority
-    });
-    await flushReplication(); // push to server before reload
-    sessionStorage.setItem('skipSync', '1'); // don't let pull overwrite restored data
     setPendingRestore(null);
     showToast(`Restored ${keys.length} data section${keys.length !== 1 ? 's' : ''}!`);
-    setTimeout(() => window.location.reload(), 500); // brief delay so toast shows
+    // Commit + replicate through the authority, then reload once — skipSync keeps
+    // the next startup pull from server-wins-merging over the restored data.
+    await coordinateSyncReload({
+      mutate: () => {
+        keys.forEach((key) => {
+          writeByKey(key, data[key]); // commit locally + queue replication via the authority
+        });
+      },
+      delayMs: 500, // brief delay so the toast shows before reload
+    });
   };
 
   const clearDataLabels = {


### PR DESCRIPTION
## Summary

Startup and manual pull now use one merge policy and one reload-safe path, routed
through the persistence authority, so local-only data survives, a malformed section
can't block others, and reloads never race.

Closes #54

## What changed

- **`src/storage/merge.js`** — new pure `planSectionMerge(localRaw, serverEntry)` owning
  the pull reconciliation policy:
  - Map data stays **server-wins on conflicts** while **local-only entries are preserved**
    (via `deepMerge`); arrays/primitives are overwritten by the server.
  - `data: null, updatedAt: null` (never-populated server section) → **push local up**.
  - `data: null, updatedAt: set` (intentional deletion) → **remove local**.
  - Malformed local content is treated as absent (server value wins).
  - A malformed server entry (non-object, or missing/undefined `data`) **throws** so the
    caller skips it — it is never mis-read as a deletion.
- **`src/storage/sync.js`** — `pullFromServer` applies `planSectionMerge` per section; only
  the malformed-server planning step is isolated in a `try/catch`, so one bad section can't
  abort the pull. Local persistence I/O (`setItem`/`removeLS`) stays outside that catch, so a
  real local write failure (e.g. quota) still surfaces as `{ ok: false }`. The `{ ok, changed }`
  contract, offline handling, and `sync-merge-conflict` notification event are unchanged.
- **`src/storage/authority.js`** — new `coordinateSyncReload({ mutate, sessionFlags, delayMs })`,
  the single owner of the reload-safe sequence: abort in-flight work (`window.stop`) →
  optional `mutate` → **final flush** → set `skipSync` (**skip-next-pull**) + caller flags →
  schedule **one** reload. A module-level guard makes it **exactly-once** per page.
- **`src/App.jsx` / `src/views/SettingsView.jsx`** — the sync-merge reload, clear-all, and
  backup restore flows now all go through `coordinateSyncReload` (one shared app-wide guard)
  instead of ad-hoc `flush → stop → reload` sequences.

## Acceptance criteria

- [x] Map data server-wins on conflicts while preserving local-only entries — `planSectionMerge` + `deepMerge`.
- [x] Never-populated server section pushes local; intentional deletion removes local — `planSectionMerge`.
- [x] Malformed content in one section can't prevent other sections from syncing — per-section isolation in `pullFromServer`.
- [x] Startup and manual pull retain success / offline / changed-data / notification outcomes — contract preserved; all prior `pullFromServer` tests still pass.
- [x] Final flush, skip-next-pull, and reload run once and admit no intervening write — `coordinateSyncReload` (guard + `window.stop` + final flush).
- [x] Tests cover merge policy, deletion semantics, malformed isolation, and exactly-once reload.

## Tests

- `src/storage/merge.test.js` — `planSectionMerge` policy: write / no-op / map-merge / array
  overwrite / never-populated push / deletion remove / malformed-local-as-absent, plus throw
  cases for malformed server entries (missing/undefined `data`, non-object entry).
- `src/storage/sync.test.js` — `pullFromServer` isolates a malformed server section, does not
  abort mid-loop, never deletes local for a data-less entry, and returns `ok:false` when a valid
  section fails to persist locally (existing pull tests unchanged).
- `src/storage/authority.reload.test.js` — `coordinateSyncReload` ordering (stop → mutate →
  flush), `skipSync` + caller-flag setting, delay handling, and exactly-once reload.

## Decisions

- The sync-merge reload path now also sets `skipSync` (in addition to `syncReload`), making
  **skip-next-pull** explicit and deterministic rather than relying on pull idempotency. This
  avoids a redundant re-pull immediately after a merge reload.
- Backup restore keeps its 500 ms pre-reload delay (so the "Restored" toast is visible) via the
  coordinator's `delayMs`. Clear-all and restore now share the same app-wide exactly-once guard.

## Validation

- `npm run test:unit` — 537 passed.
- `npm run test:e2e` — 72 passed, 6 skipped.
- `npm run build` — succeeds.

No user-visible UI changed (data-layer + reload coordination only); the existing `@visual`
Playwright suite passes unchanged.

## Review notes

Dual-model review (GPT-5.5 quality + Claude Opus 4.8 security) ran against the diff.

- **Security (Claude Opus 4.8):** No material findings. Confirmed no prototype pollution
  (`deepMerge` still gates `__proto__`/`constructor`/`prototype`; the `merged = data` fallback
  only serializes), hostile/malformed payloads are handled without crashing, `sessionFlags`
  carries no untrusted data, and logs expose no secrets (only the key name + error). One
  pre-existing, out-of-scope note: `pushToServer` interpolates the key into the fetch URL
  without `encodeURIComponent` — unchanged from `main`, bounded (same-origin own-NAS), left as
  a future hardening.
- **Quality (GPT-5.5):** Two findings, both **adopted** in commit `fix: treat malformed server
  sections strictly…`:
  1. (High) `planSectionMerge` treated `data === undefined` like `data === null`, so a malformed
     entry could delete/push local data — now throws and the section is skipped.
  2. (Medium) local `setItem` quota failures were swallowed by the per-section catch and reported
     as `ok:true` — the catch was narrowed to malformed-server planning, so local write failures
     now surface as `ok:false`.
- No cosmetic/low-value findings were set aside.
