### PR TITLE
feat: clear TrainLog data through the persistence authority

### DIFF
--- a/e2e/settings-visual.e2e.js
+++ b/e2e/settings-visual.e2e.js
@@ -1,6 +1,43 @@
 import { test, expect } from '@playwright/test';
 import { gotoCleanApp, importSampleCsv, captureVisualEvidence } from './helpers.js';
 
+test.describe('Settings clear behavior @visual', () => {
+  test('Clear all durable data does not resurrect it after the reload', async ({ page }, testInfo) => {
+    await gotoCleanApp(page);
+    await importSampleCsv(page);
+
+    // Data is present: an imported workout is offered on the Training screen.
+    await expect(page.getByRole('button', { name: /Preview Upper Body A/ })).toBeVisible();
+
+    // Settings → Clear Data, leave every section checked (a full clear).
+    await page.getByRole('button', { name: 'Settings' }).click();
+    await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+    await page.getByRole('button', { name: 'Clear Data...' }).click();
+    await expect(page.getByRole('heading', { name: 'Clear Data' })).toBeVisible();
+
+    const selectAll = page.locator('.settings-clear-modal__check--all input[type="checkbox"]');
+    await expect(selectAll).toBeChecked();
+
+    // Confirm the clear. This commits + replicates deletions through the
+    // authority, then coordinates a single reload.
+    await page.getByRole('button', { name: /^Delete/ }).click();
+
+    // After the reload the app returns to the import screen — the cleared
+    // workouts are gone and did not come back on startup.
+    await expect(page.getByRole('heading', { name: 'Import TrainHeroic CSV' })).toBeVisible();
+    await expect(page.getByRole('button', { name: /Preview Upper Body A/ })).toHaveCount(0);
+
+    // The durable localStorage sections are empty after the clear+reload.
+    const remaining = await page.evaluate(() =>
+      ['th_workouts', 'th_schedule', 'th_logs', 'th_templates', 'th_yt_links', 'th_active']
+        .filter((k) => localStorage.getItem(k) !== null)
+    );
+    expect(remaining).toEqual([]);
+
+    await captureVisualEvidence(page, testInfo, 'clear-all-returns-to-import');
+  });
+});
+
 test.describe('Settings visual states @visual', () => {
   test('Clear Data dialog shows visible checked states', async ({ page }, testInfo) => {
     await gotoCleanApp(page);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,8 +6,7 @@ import { useWorkoutLogs } from './hooks/useWorkoutLogs';
 import { useActiveWorkout } from './hooks/useActiveWorkout';
 import { useTemplates } from './hooks/useTemplates';
 import { useSync } from './hooks/useSync';
-import { retryReplication, removeByKey, coordinateSyncReload } from './storage/authority';
-import { clearLS } from './storage/index';
+import { retryReplication, clearByKeys, coordinateSyncReload } from './storage/authority';
 import { useToast } from './components/Toast';
 import { applyTemplateChange, applyScheduleChange, applyNoteChange, applyImport } from './orchestrator';
 import {
@@ -61,7 +60,7 @@ export default function App() {
     saveTemplates,
     duplicateTemplate,
   } = useTemplates();
-  const { syncStatus, lastSynced, pullSync, pushSync, clearServer } = useSync();
+  const { syncStatus, lastSynced, pullSync, pushSync } = useSync();
   const showToast = useToast();
 
   // Orchestration: snapshot builder + write dispatcher
@@ -244,19 +243,16 @@ export default function App() {
     return [...names].sort((a, b) => a.localeCompare(b));
   }, [workouts]);
 
-  // Shared clear-all handler (used by SettingsView in two routes)
+  // Shared clear handler (used by SettingsView in two routes). Both selective
+  // (`keys` set) and full (`keys` omitted) clears run through the authority so
+  // each section is removed locally AND its deletion replicated; the shared
+  // reload coordination flushes those deletions and skips the next pull so
+  // cleared data can't resurrect.
   const handleClearAllData = useCallback(async (keys) => {
     await coordinateSyncReload({
-      mutate: async () => {
-        if (!keys) {
-          await clearServer();
-          clearLS();
-        } else {
-          keys.forEach((k) => removeByKey(k));
-        }
-      },
+      mutate: () => clearByKeys(keys),
     });
-  }, [clearServer]);
+  }, []);
 
   const handlePullSync = useCallback(async () => {
     const { ok, changed } = await pullSync();

--- a/src/hooks/useSync.js
+++ b/src/hooks/useSync.js
@@ -3,7 +3,6 @@ import {
   checkReplicationHealth,
   pullReplication,
   pushAllReplication,
-  clearReplication,
 } from '../storage/authority';
 import { getSyncedKeys } from '../storage/registry';
 
@@ -57,10 +56,5 @@ export function useSync() {
     return ok;
   }, []);
 
-  // Clear all data on server
-  const clearServer = useCallback(async () => {
-    return clearReplication(ALL_KEYS);
-  }, []);
-
-  return { syncStatus, lastSynced, pullSync, pushSync, clearServer };
+  return { syncStatus, lastSynced, pullSync, pushSync };
 }

--- a/src/storage/authority.clear.test.js
+++ b/src/storage/authority.clear.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import { createAuthority } from './authority';
+import { createMemoryStorageAdapter } from './adapters/browserStorage';
+import { getAllKeys } from './registry';
+import {
+  LS_WORKOUTS,
+  LS_TEMPLATES,
+  LS_SCHEDULE,
+  LS_WORKOUT_LOGS,
+  LS_ACTIVE_SESSION,
+  LS_YOUTUBE_LINKS,
+} from '../constants';
+
+/**
+ * Clear paths for TrainLog data run through the persistence authority so a
+ * "clear" removes each durable section locally AND replicates the deletion to
+ * the server through the shared push path — the same seam writes use. These
+ * tests exercise that boundary against an in-memory storage adapter and a fake
+ * transport that mirrors a server store, so we can prove a subsequent pull can
+ * never resurrect cleared data.
+ */
+function setup(initial = {}) {
+  const storageInitial = {};
+  const server = {};
+  for (const [key, value] of Object.entries(initial)) {
+    storageInitial[key] = JSON.stringify(value);
+    server[key] = value;
+  }
+  const storage = createMemoryStorageAdapter({ initial: storageInitial });
+  const pushes = [];
+  const transport = {
+    async pullAll() {
+      // Server wins over local for keys the server holds.
+      const sections = {};
+      for (const [key, value] of Object.entries(server)) {
+        if (value !== null && value !== undefined) sections[key] = value;
+      }
+      return { ok: true, sections };
+    },
+    async push(key, data) {
+      pushes.push({ key, data, committed: storage.getItem(key) });
+      server[key] = data; // null deletion mirrors the real server contract
+      return { ok: true, status: 200 };
+    },
+    async pushAll() {
+      return { ok: false, status: null };
+    },
+  };
+  const authority = createAuthority({ storage, transport });
+  return { storage, transport, pushes, server, authority };
+}
+
+describe('persistence authority — clearByKeys (selective)', () => {
+  it('removes only the chosen sections locally and pushes their deletions remotely', async () => {
+    const { authority, storage, server, pushes } = setup({
+      [LS_WORKOUTS]: { 'Bench Press': {} },
+      [LS_TEMPLATES]: { t1: { id: 't1' } },
+      [LS_SCHEDULE]: { '2026-07-17': 'Upper A' },
+    });
+
+    await authority.clearByKeys([LS_WORKOUTS, LS_SCHEDULE]);
+
+    // Chosen sections gone locally...
+    expect(storage.getItem(LS_WORKOUTS)).toBeNull();
+    expect(storage.getItem(LS_SCHEDULE)).toBeNull();
+    // ...and remotely (null deletion pushed through the shared path).
+    expect(server[LS_WORKOUTS]).toBeNull();
+    expect(server[LS_SCHEDULE]).toBeNull();
+    const clearedKeys = pushes.map((p) => p.key).sort();
+    expect(clearedKeys).toEqual([LS_WORKOUTS, LS_SCHEDULE].sort());
+    pushes.forEach((p) => expect(p.data).toBeNull());
+
+    // Untouched section survives locally and on the server.
+    expect(storage.getItem(LS_TEMPLATES)).toBe('{"t1":{"id":"t1"}}');
+    expect(server[LS_TEMPLATES]).toEqual({ t1: { id: 't1' } });
+  });
+
+  it('commits the local deletion before the network push fires', async () => {
+    const { authority, pushes } = setup({ [LS_WORKOUTS]: { a: 1 } });
+    await authority.clearByKeys([LS_WORKOUTS]);
+    expect(pushes).toHaveLength(1);
+    // At the moment the push fired the local value was already removed.
+    expect(pushes[0].committed).toBeNull();
+  });
+});
+
+describe('persistence authority — clearByKeys (full)', () => {
+  it('removes every durable section locally and remotely when given no keys', async () => {
+    const seed = {
+      [LS_WORKOUTS]: { w: 1 },
+      [LS_TEMPLATES]: { t: 1 },
+      [LS_SCHEDULE]: { s: 1 },
+      [LS_WORKOUT_LOGS]: { l: 1 },
+      [LS_YOUTUBE_LINKS]: { y: 1 },
+      [LS_ACTIVE_SESSION]: { logKey: 'x' },
+    };
+    const { authority, storage, server, pushes } = setup(seed);
+
+    await authority.clearByKeys();
+
+    for (const key of getAllKeys()) {
+      expect(storage.getItem(key)).toBeNull();
+      expect(server[key]).toBeNull();
+    }
+    expect(pushes.map((p) => p.key).sort()).toEqual(getAllKeys().sort());
+  });
+
+  it('treats an empty key list as a full clear', async () => {
+    const { authority, storage } = setup({ [LS_WORKOUTS]: { w: 1 } });
+    await authority.clearByKeys([]);
+    for (const key of getAllKeys()) {
+      expect(storage.getItem(key)).toBeNull();
+    }
+  });
+});
+
+describe('persistence authority — clear then reload (no resurrection)', () => {
+  it('a pull after a full clear cannot bring cleared data back', async () => {
+    const seed = {
+      [LS_WORKOUTS]: { w: 1 },
+      [LS_TEMPLATES]: { t: 1 },
+    };
+    const { authority, storage, transport } = setup(seed);
+
+    await authority.clearByKeys();
+
+    // Simulate the post-clear reload path pulling from the server. Because the
+    // clear pushed null deletions, the server holds nothing to merge back.
+    const { sections } = await transport.pullAll();
+    expect(sections[LS_WORKOUTS]).toBeUndefined();
+    expect(sections[LS_TEMPLATES]).toBeUndefined();
+
+    // Reads through the authority return section defaults, not the old data.
+    expect(authority.readByKey(LS_WORKOUTS)).toEqual({});
+    expect(authority.readByKey(LS_TEMPLATES)).toEqual({});
+    expect(storage.getItem(LS_WORKOUTS)).toBeNull();
+  });
+
+  it('a selective clear leaves untouched sections available to a later pull', async () => {
+    const { authority, transport } = setup({
+      [LS_WORKOUTS]: { w: 1 },
+      [LS_TEMPLATES]: { t: 1 },
+    });
+
+    await authority.clearByKeys([LS_WORKOUTS]);
+
+    const { sections } = await transport.pullAll();
+    expect(sections[LS_WORKOUTS]).toBeUndefined();
+    expect(sections[LS_TEMPLATES]).toEqual({ t: 1 });
+  });
+});

--- a/src/storage/authority.js
+++ b/src/storage/authority.js
@@ -26,7 +26,7 @@
 
 import { createPersistence } from './persistence';
 import { createBrowserStorageAdapter } from './adapters/browserStorage';
-import { getSectionByKey } from './registry';
+import { getSectionByKey, getAllKeys } from './registry';
 import {
   pushToServer,
   flushPendingPushes,
@@ -111,7 +111,22 @@ export function createAuthority({ storage, transport, notify = defaultNotify }) 
     return persistence.remove(section.id);
   }
 
-  return { persistence, readByKey, writeByKey, removeByKey };
+  /**
+   * Clear durable sections through the authority. With no keys (or an empty
+   * list) this is a registry-driven full clear of every durable section; with a
+   * key list it clears only those sections. Each target is removed locally and
+   * its deletion replicated through the same shared push path a write uses, so
+   * cleared data cannot resurrect on a later pull. Unknown keys are ignored.
+   *
+   * @param {string[]} [keys] - sections to clear; omit/empty for a full clear
+   * @returns {Promise<void>}
+   */
+  async function clearByKeys(keys) {
+    const targets = keys && keys.length ? keys : getAllKeys();
+    await Promise.all(targets.map((key) => removeByKey(key)));
+  }
+
+  return { persistence, readByKey, writeByKey, removeByKey, clearByKeys };
 }
 
 /** Best-effort user alert; a no-op where `alert` is unavailable (SSR/tests). */
@@ -151,6 +166,14 @@ export function writeByKey(key, value) {
 /** Remove a durable section by its localStorage key (production singleton). */
 export function removeByKey(key) {
   return getAuthority().removeByKey(key);
+}
+
+/**
+ * Clear durable sections by localStorage key (production singleton). Omit `keys`
+ * (or pass an empty list) for a registry-driven full clear.
+ */
+export function clearByKeys(keys) {
+  return getAuthority().clearByKeys(keys);
 }
 
 /* -------------------------------------------------------------------------- *

--- a/src/storage/index.js
+++ b/src/storage/index.js
@@ -43,13 +43,3 @@ export function removeLS(key) {
     return false;
   }
 }
-
-export function clearLS() {
-  try {
-    localStorage.clear();
-    return true;
-  } catch (e) {
-    console.error('Error clearing localStorage:', e);
-    return false;
-  }
-}

--- a/src/storage/registry.js
+++ b/src/storage/registry.js
@@ -68,3 +68,8 @@ export function getSyncedKeys() {
 export function getBackupKeys() {
   return SECTIONS.filter((s) => s.backup).map((s) => s.key);
 }
+
+/** localStorage keys for every durable section (registry-driven full clear). */
+export function getAllKeys() {
+  return SECTIONS.map((s) => s.key);
+}

--- a/src/storage/registry.test.js
+++ b/src/storage/registry.test.js
@@ -5,6 +5,7 @@ import {
   getSectionByKey,
   getSyncedKeys,
   getBackupKeys,
+  getAllKeys,
 } from './registry';
 import {
   LS_WORKOUTS,
@@ -54,6 +55,20 @@ describe('persistence registry', () => {
 
   it('synced keys cover all six sections including the session for crash recovery', () => {
     const keys = getSyncedKeys();
+    expect(keys.sort()).toEqual(
+      [
+        LS_WORKOUTS,
+        LS_SCHEDULE,
+        LS_YOUTUBE_LINKS,
+        LS_WORKOUT_LOGS,
+        LS_TEMPLATES,
+        LS_ACTIVE_SESSION,
+      ].sort()
+    );
+  });
+
+  it('all keys cover every durable section for a registry-driven clear', () => {
+    const keys = getAllKeys();
     expect(keys.sort()).toEqual(
       [
         LS_WORKOUTS,


### PR DESCRIPTION
## Summary

Routes TrainLog's **Clear Data** (both selective and full clear) through the persistence authority so a clear removes each durable section locally **and** replicates the deletion to the server through the shared push path — the same seam writes use.

Previously:
- **Full clear** used `localStorage.clear()` (a blunt wipe that also removed non-durable app state) plus a fire-and-forget bulk `clearServerData` fetch issued outside the authority with no retry recovery.
- **Selective clear** used per-key `removeByKey`.

Now both paths share one registry-driven mechanism:
- `registry.getAllKeys()` enumerates every durable section.
- `authority.clearByKeys(keys)` removes each target locally and pushes a `null` deletion through the shared replication path. Omitting `keys` (or passing an empty list) is a full clear.
- Both paths run under `coordinateSyncReload`, which aborts in-flight work, flushes the queued deletions, and sets `skipSync` so cleared data cannot resurrect on the coordinated reload's pull.

The Clear Data confirmation modal and the "Cleared N data section(s)" toast are unchanged.

## Acceptance criteria

- [x] Selective clearing removes only chosen sections locally and remotely.
- [x] Clear all removes every supported durable section (registry-driven) while preserving confirmation + feedback behavior.
- [x] Both paths use shared reload coordination (`coordinateSyncReload`), admit no intervening write, and prevent cleared data from returning on the coordinated reload's pull (`skipSync` + null deletions on the server).
- [x] Tests cover selective clear, full clear, and clear-then-reload with a fake transport.

## Decisions

- **Unified clear through `removeByKey` per key** rather than keeping the bulk `clearServerData` fetch. This keeps the authority the single owner of replication (established in #70/#71/#72) and makes selective and full clear identical. `clearReplication`/`clearServerData` remain as a tested authority facade capability but are no longer on the clear path.
- **Removed now-dead code**: `clearLS()` (the blunt full-wipe footgun this slice moves away from) and `useSync.clearServer()`.
- **Full clear = registry keys** (`getAllKeys()`), which are exactly the six sections the Settings modal already lists. Non-durable UI preferences (`th_settings`) are intentionally preserved — clearing workout data no longer wipes rest-timer/notification prefs, matching the registry's definition of "durable section."

## Tests

- `src/storage/registry.test.js` — `getAllKeys()` covers every durable section.
- `src/storage/authority.clear.test.js` (new) — selective clear (only chosen sections removed local+remote, commit-before-push), full clear (all sections, no-arg and empty-list), and clear-then-reload proving a pull cannot resurrect cleared data, all against an in-memory storage adapter + fake transport that mirrors a server store.
- `e2e/settings-visual.e2e.js` — new `@visual` journey: import → Clear Data (all) → Delete → reload returns to the Import screen with every `th_*` durable key empty (no resurrection).

## Validation

- `npm run test:unit` — 544 passed.
- `npm run test:e2e` — 74 passed.
- `npm run build` — succeeded.
- `npm run test:e2e:visual` — evidence captured and inspected:
  - `artifacts/visual/chromium/clear-all-returns-to-import.png`
  - `artifacts/visual/mobile-chrome/clear-all-returns-to-import.png`
  - `artifacts/visual/chromium/clear-data-all-checked.png` (modal confirmation intact, "Delete (6)")

Inspected desktop + mobile: after clear+reload the app shows a clean Import screen, nav bar visible, no clipping/overflow, dark theme consistent.

## Review notes

Dual-model review run (gpt-5.5 quality/correctness + claude-opus-4.8 security).

- **Security (claude-opus-4.8): 0 findings.** Verified the clear path is registry-constrained (`getSectionByKey` filters unregistered keys — no push fires for arbitrary keys), pushes only a hardcoded `null` value, path-encodes keys, and leaves no sensitive residue (`th_settings` holds only UI prefs; app has no auth). The change *narrows* the blast radius versus the old `localStorage.clear()` + bulk clear.

- **Quality (gpt-5.5): 1 finding — set aside with justification.** The reviewer flagged that if a clear's server deletion PUT *fails* and the user later reopens the app on a fresh session, a subsequent pull could rewrite the old (still-on-server) data back locally, because startup runs `pullSync()` before `retryReplication()` and skips retry when the pull changed data.

  This is a **pre-existing property of the offline-first sync + startup-ordering** (`src/App.jsx` startup effect, `src/storage/sync.js` retry ordering), not introduced or worsened by this PR:
  - Selective clear is behaviorally identical to `origin/main` (both go through `removeByKey`; this PR additionally `await`s the removals via `Promise.all`, which is strictly safer).
  - Full clear is *improved*: the old `clearServer()` bulk fetch was fire-and-forget with **no** retry recovery on failure, whereas the new path records retry state (payload `null`) via `flushPendingPushes`, giving the deletion an eventual-consistency recovery path.
  - The AC "prevent cleared data from returning on pull" refers to the coordinated reload's pull, which is reliably suppressed by `skipSync`; the failed-deletion-then-restart edge is governed by the same eventual-consistency retry machinery as every offline write.

  Fully closing this edge (e.g. deletion tombstones, or reordering startup retry-before-pull) is a cross-cutting change to the whole sync layer, out of scope for this slice and best tracked as a dedicated follow-up. No fix commit made; the change here strictly reduces the risk relative to the prior code.

Closes #56
