### PR TITLE
feat: restore backups atomically through the persistence authority

### DIFF
--- a/src/storage/backup.js
+++ b/src/storage/backup.js
@@ -1,10 +1,14 @@
 import { readLS } from './index';
 import { getBackupKeys } from './registry';
+import { writeByKey, coordinateSyncReload } from './authority';
 
 // The sections a full backup must round-trip, sourced from the shared section
 // registry. The in-progress active session scratch (LS_ACTIVE_SESSION /
 // th_active) is registered with `backup: false`, so it is intentionally excluded.
 export const BACKUP_KEYS = getBackupKeys();
+
+/** Shown when a chosen file contains no recognizable TrainLog sections. */
+export const NO_SECTIONS_MESSAGE = 'No TrainLog data found in that file';
 
 /**
  * Build a complete backup snapshot. Every required section is always present —
@@ -20,4 +24,66 @@ export function buildBackup() {
     backup[key] = readLS(key, {});
   }
   return backup;
+}
+
+/** A plain (non-array, non-null) object — the shape every backup section holds. */
+function isPlainObject(value) {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Validate a parsed backup object and extract its recognizable sections. A
+ * section is *recognized* only when its key is a known backup key and its value
+ * is a plain object map — so the excluded recovery Session, unknown keys, and
+ * malformed (non-object) sections are all ignored. This runs before any write so
+ * an unusable file is rejected atomically, never leaving a partial restore.
+ *
+ * @param {unknown} data - the parsed contents of a backup file
+ * @returns {{ keys: string[] }} the recognized backup keys to restore
+ * @throws {Error} NO_SECTIONS_MESSAGE when nothing recognizable is present
+ */
+export function parseBackup(data) {
+  if (!isPlainObject(data)) {
+    throw new Error(NO_SECTIONS_MESSAGE);
+  }
+  const keys = BACKUP_KEYS.filter((key) => isPlainObject(data[key]));
+  if (keys.length === 0) {
+    throw new Error(NO_SECTIONS_MESSAGE);
+  }
+  return { keys };
+}
+
+/**
+ * Restore a backup atomically through the persistence authority.
+ *
+ * The file is validated first ({@link parseBackup}); if it holds no recognizable
+ * sections it is rejected *before any write*. Otherwise every recognized section
+ * is persisted through the authority — committing locally and replicating
+ * remotely — inside the shared reload-safe coordinator's `mutate` step, so the
+ * writes are flushed to the server and `skipSync` is set before the single
+ * reload. That prevents a stale startup pull from server-wins-merging over the
+ * data we just restored.
+ *
+ * @param {unknown} data - the parsed contents of a backup file
+ * @param {Object} [deps]
+ * @param {(key: string, value: unknown) => unknown} [deps.write] - persistence authority write
+ * @param {(opts: { mutate: () => void, delayMs?: number }) => Promise<unknown>} [deps.coordinateReload]
+ * @param {number} [deps.delayMs=500] - delay before the reload (lets a toast show)
+ * @returns {Promise<{ keys: string[] }>} the sections that were restored
+ * @throws {Error} NO_SECTIONS_MESSAGE when the backup is unrecognizable
+ */
+export async function restoreBackup(
+  data,
+  { write = writeByKey, coordinateReload = coordinateSyncReload, delayMs = 500 } = {}
+) {
+  const { keys } = parseBackup(data); // rejects before any write when unrecognizable
+  await coordinateReload({
+    mutate: () => {
+      for (const key of keys) {
+        write(key, data[key]); // commit locally + queue replication via the authority
+      }
+    },
+    delayMs,
+  });
+  return { keys };
 }

--- a/src/storage/backup.test.js
+++ b/src/storage/backup.test.js
@@ -10,7 +10,13 @@ vi.mock('../storage/index', () => {
   };
 });
 
-import { buildBackup, BACKUP_KEYS } from './backup';
+import {
+  buildBackup,
+  BACKUP_KEYS,
+  parseBackup,
+  restoreBackup,
+  NO_SECTIONS_MESSAGE,
+} from './backup';
 import { __store as store } from '../storage/index';
 import {
   LS_WORKOUTS,
@@ -56,5 +62,76 @@ describe('buildBackup', () => {
     const backup = buildBackup();
     expect(BACKUP_KEYS).not.toContain(LS_ACTIVE_SESSION);
     expect(backup).not.toHaveProperty(LS_ACTIVE_SESSION);
+  });
+});
+
+describe('parseBackup', () => {
+  it('rejects a file with no recognizable TrainLog sections before any restore', () => {
+    expect(() => parseBackup({ not_a_section: {}, th_settings: {} })).toThrow(
+      NO_SECTIONS_MESSAGE
+    );
+    expect(() => parseBackup(null)).toThrow(NO_SECTIONS_MESSAGE);
+    expect(() => parseBackup('nonsense')).toThrow(NO_SECTIONS_MESSAGE);
+  });
+
+  it('returns only the recognized backup keys, ignoring the excluded session key', () => {
+    const { keys } = parseBackup({
+      [LS_TEMPLATES]: {},
+      [LS_WORKOUTS]: { 'Upper A': {} },
+      [LS_ACTIVE_SESSION]: { inProgress: true }, // durable but never backed up
+      bogus: 5,
+    });
+    expect(keys.sort()).toEqual([LS_TEMPLATES, LS_WORKOUTS].sort());
+  });
+
+  it('treats a non-object section value as unrecognized', () => {
+    const { keys } = parseBackup({
+      [LS_WORKOUT_LOGS]: {},
+      [LS_WORKOUTS]: 'oops',
+      [LS_SCHEDULE]: null,
+    });
+    expect(keys).toEqual([LS_WORKOUT_LOGS]);
+  });
+});
+
+describe('restoreBackup', () => {
+  it('rejects an unrecognized backup without persisting anything', async () => {
+    const write = vi.fn();
+    const coordinateReload = vi.fn();
+    await expect(
+      restoreBackup({ bogus: {} }, { write, coordinateReload })
+    ).rejects.toThrow(NO_SECTIONS_MESSAGE);
+    expect(write).not.toHaveBeenCalled();
+    expect(coordinateReload).not.toHaveBeenCalled();
+  });
+
+  it('persists every recognized section through the authority inside the reload-safe path', async () => {
+    const events = [];
+    const write = vi.fn((key) => events.push(`write:${key}`));
+    const coordinateReload = vi.fn(async ({ mutate }) => {
+      events.push('reload:start');
+      await mutate();
+      events.push('reload:end');
+    });
+    const data = {
+      [LS_TEMPLATES]: { t1: { title: 'PPL' } },
+      [LS_WORKOUTS]: { 'Upper A': { title: 'Upper A' } },
+      [LS_SCHEDULE]: {},
+      [LS_ACTIVE_SESSION]: { inProgress: true },
+    };
+
+    const { keys } = await restoreBackup(data, { write, coordinateReload });
+
+    expect(keys.sort()).toEqual([LS_TEMPLATES, LS_WORKOUTS, LS_SCHEDULE].sort());
+    expect(write).toHaveBeenCalledWith(LS_TEMPLATES, data[LS_TEMPLATES]);
+    expect(write).toHaveBeenCalledWith(LS_WORKOUTS, data[LS_WORKOUTS]);
+    expect(write).toHaveBeenCalledWith(LS_SCHEDULE, data[LS_SCHEDULE]);
+    // Never persists the excluded recovery session, even when present in the file.
+    expect(write).not.toHaveBeenCalledWith(LS_ACTIVE_SESSION, expect.anything());
+    // Every persist happens INSIDE the reload-safe coordinator's mutate step.
+    expect(coordinateReload).toHaveBeenCalledTimes(1);
+    expect(events[0]).toBe('reload:start');
+    expect(events[events.length - 1]).toBe('reload:end');
+    expect(events).toContain(`write:${LS_TEMPLATES}`);
   });
 });

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -27,8 +27,7 @@ import {
 import Modal from '../components/Modal';
 import FeedbackModal from '../components/FeedbackModal';
 import { useToast } from '../components/Toast';
-import { buildBackup, BACKUP_KEYS } from '../storage/backup';
-import { writeByKey, coordinateSyncReload } from '../storage/authority';
+import { buildBackup, parseBackup, restoreBackup, NO_SECTIONS_MESSAGE } from '../storage/backup';
 import {
   LS_WORKOUTS,
   LS_SCHEDULE,
@@ -197,20 +196,24 @@ export default function SettingsView({
 
       const reader = new FileReader();
       reader.onload = (ev) => {
+        let data;
         try {
-          const data = JSON.parse(ev.target.result);
-          const keys = BACKUP_KEYS.filter(
-            (key) => data[key] !== undefined && data[key] !== null
-          );
-          if (keys.length === 0) {
-            showToast('No TrainLog data found in that file', 'error');
-            return;
-          }
-          // Restore overwrites existing data — confirm before applying.
-          setPendingRestore({ data, keys });
+          data = JSON.parse(ev.target.result);
         } catch {
           showToast('Invalid backup file', 'error');
+          return;
         }
+        let keys;
+        try {
+          // Validate the backup before any write; unrecognizable files are
+          // rejected here so a restore can never partially apply.
+          ({ keys } = parseBackup(data));
+        } catch {
+          showToast(NO_SECTIONS_MESSAGE, 'error');
+          return;
+        }
+        // Restore overwrites existing data — confirm before applying.
+        setPendingRestore({ data, keys });
       };
       reader.readAsText(file);
     };
@@ -222,16 +225,10 @@ export default function SettingsView({
     const { data, keys } = pendingRestore;
     setPendingRestore(null);
     showToast(`Restored ${keys.length} data section${keys.length !== 1 ? 's' : ''}!`);
-    // Commit + replicate through the authority, then reload once — skipSync keeps
-    // the next startup pull from server-wins-merging over the restored data.
-    await coordinateSyncReload({
-      mutate: () => {
-        keys.forEach((key) => {
-          writeByKey(key, data[key]); // commit locally + queue replication via the authority
-        });
-      },
-      delayMs: 500, // brief delay so the toast shows before reload
-    });
+    // restoreBackup validates, persists through the authority (local + remote),
+    // then reloads once via the shared reload-safe path — skipSync keeps the next
+    // startup pull from server-wins-merging over the restored data.
+    await restoreBackup(data);
   };
 
   const clearDataLabels = {


### PR DESCRIPTION
## What & why

Settings now exports and restores TrainLog data through the authoritative
persistence path, with validation up front so a restore can never partially
apply or be overwritten by a stale startup pull.

Restore logic that previously lived inline in `SettingsView` is extracted into
two tested functions in the backup module:

- **`parseBackup(data)`** — validates a parsed backup and returns the recognized
  sections. A section is recognized only when its key is a known backup key and
  its value is a plain object map, so unknown keys, `null`/non-object sections,
  and the excluded recovery **Session** are all ignored. A file with no
  recognizable TrainLog sections throws `NO_SECTIONS_MESSAGE` **before any
  write** — atomic rejection, no partial restore.
- **`restoreBackup(data, deps)`** — validates first, then persists every
  recognized section through the **persistence authority** (`writeByKey` →
  local commit + remote replication) inside `coordinateSyncReload`'s `mutate`
  step. That flushes pending pushes and sets `skipSync` before the single
  reload, so a stale startup pull can't server-wins-merge over restored data.

`SettingsView` delegates import validation and restore to these functions and
retains its existing success (`Restored N data sections!`) and error
(`Invalid backup file`, `No TrainLog data found in that file`) feedback.

## Acceptance criteria

- [x] A full backup includes Templates, Workouts, Schedule, YouTube links, and
      Logs even when empty, and excludes the recovery Session. (`buildBackup`,
      registry-driven; unchanged, still covered.)
- [x] A backup with no recognizable TrainLog sections is rejected before any
      write (`parseBackup` throws before `restoreBackup` touches the authority).
- [x] A valid restore validates all recognized sections, persists them locally
      and remotely, then uses the shared reload-safe path (`restoreBackup` →
      authority write inside `coordinateSyncReload`).
- [x] Settings retains current success and error feedback.
- [x] Backup and restore tests exercise the persistence authority (restore tests
      assert writes land through the injected authority write inside the
      reload-safe coordinator, and never restore the recovery Session).

## Decisions

- **Recognized = known backup key with a plain-object value.** Non-object
  section values (strings, arrays, `null`) are treated as unrecognized rather
  than throwing, matching "recognizable TrainLog sections"; a file with zero
  recognized sections is rejected. This keeps a malformed section from producing
  a partial restore while tolerating benign extra keys (e.g. `th_settings`).
- **Writes stay inside `coordinateSyncReload`'s `mutate`.** Preserves the
  existing ordering (abort in-flight work → mutate → final flush → skipSync →
  reload) so no write slips past the final flush.
- Kept the 500ms reload delay so the success toast is visible before reload.

## Testing

- `npm run test:unit` — 549 passed (8 in `backup.test.js`, incl. 4 new
  parse/restore cases exercising the authority).
- `npm run test:e2e` — 74 passed / 6 skipped.
- `npm run build` — clean.
- `npm run test:e2e:visual` — inspected desktop + mobile evidence of the
  affected Settings surface (UI unchanged by this logic refactor):
  - `artifacts/visual/chromium/backup-actions-desktop.png`
  - `artifacts/visual/mobile-chrome/backup-actions-mobile.png`

## Review notes

Dual-model code review before merge:

- **gpt-5.5 (code quality & correctness):** no significant issues found.
- **claude-opus-4.8 (security):** confirmed the changed lines are clean — no
  prototype pollution (only the frozen `BACKUP_KEYS` allowlist is ever read, no
  spread over untrusted keys), no unexpected storage-key overwrite (writes gated
  by `BACKUP_KEYS` + `getSectionByKey`, recovery Session excluded), and noted the
  new `isPlainObject` validation makes restore **stricter** than the code it
  replaces. One finding — an unsanitized YouTube-link `href` sink in
  `ActiveWorkoutView.jsx` reachable via a malicious restored `th_youtube_links`
  value — was flagged as **pre-existing and out of this slice's scope** (the sink
  lives in another feature's file, and this diff neither introduces nor worsens
  it). Filed as follow-up #75 rather than expanding this restore slice; the
  durable fix is `safeYouTubeHref` at the sink, which multiple write paths reach.

Closes #55

