### PR TITLE
feat: keep Template targets consistent with an active Session

### DIFF
--- a/e2e/template-session-target-consistency.e2e.js
+++ b/e2e/template-session-target-consistency.e2e.js
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+import { captureVisualEvidence, gotoCleanApp, importSampleCsv } from './helpers';
+
+// Regression journeys proving prescribed-set *targets* stay consistent between a
+// Template and its materialized Workout in both directions, exercised through the
+// real UI (which drives the production lifecycle authority, `applyTemplateChange`).
+
+async function startLowerBodyB(page) {
+  await page.getByRole('button', { name: /Preview Lower Body B/ }).click();
+  await page.getByRole('button', { name: 'Start Now' }).click();
+  await expect(page.getByRole('button', { name: 'Finish (0/7 sets)' })).toBeVisible();
+}
+
+async function openLowerBodyBTemplate(page) {
+  await page.getByRole('button', { name: 'Library' }).click();
+  await page.getByRole('tab', { name: 'Templates' }).click();
+  await page.getByRole('button', { name: /Lower Body B/ }).click();
+  await expect(page.locator('.tpl-editor')).toBeVisible();
+}
+
+test('@visual Template target edit propagates to the materialized Workout', async ({ page }, testInfo) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+
+  // Edit the first exercise's first set target (Leg Swings reps) in the Template.
+  await openLowerBodyBTemplate(page);
+  const firstSetReps = page.locator('.tpl-editor__set-input').first();
+  await firstSetReps.fill('9');
+  await expect(firstSetReps).toHaveValue('9');
+  await page.getByRole('button', { name: 'Save Template' }).click();
+
+  // Start the materialized Workout — its first set target must reflect the edit.
+  await expect(page.getByRole('tab', { name: 'Templates' })).toBeVisible();
+  await page.getByRole('button', { name: 'Training' }).click();
+  await startLowerBodyB(page);
+
+  const firstTarget = page.locator('.log-set-row__target').first();
+  await expect(firstTarget).toHaveText('9 × BW');
+  await captureVisualEvidence(page, testInfo, 'session-target-reflects-template-edit');
+});
+
+test('@visual Session target confirmation propagates back to the Template', async ({ page }, testInfo) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+
+  // Start the Workout, edit the first set target, and confirm via the pencil.
+  await startLowerBodyB(page);
+  await page.getByRole('button', { name: 'Edit workout' }).click();
+  const firstEditReps = page.locator('.log-set-row__input').first();
+  await firstEditReps.fill('5');
+  await expect(firstEditReps).toHaveValue('5');
+  await page.getByRole('button', { name: 'Save edits' }).click();
+
+  // Leave the active session (progress is saved) so the bottom nav returns.
+  await page.getByRole('button', { name: 'Cancel workout' }).click();
+  await page.getByRole('button', { name: 'Cancel Workout', exact: true }).click();
+  await expect(page.getByRole('heading', { name: /Good (morning|afternoon|evening)/ })).toBeVisible();
+
+  // Confirmed target must now appear on the matching Template.
+  await openLowerBodyBTemplate(page);
+  const templateFirstSetReps = page.locator('.tpl-editor__set-input').first();
+  await expect(templateFirstSetReps).toHaveValue('5');
+  await captureVisualEvidence(page, testInfo, 'template-target-reflects-session-confirmation');
+});

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -137,12 +137,15 @@ export function applyTemplateChange(snap, change) {
     // edited target (prescribed set) stays in sync in both directions. On a
     // rename the workout also moves to the new key/title; either way it adopts
     // the Template's blocks. This is the same explicit-save lifecycle path the
-    // active-Session direction uses via `syncBlocks`.
-    const sourceName = snap.workouts[oldName] ? oldName : null;
+    // active-Session direction uses via `syncBlocks`. When the old key is absent
+    // but a stale workout already sits under the new name, refresh that one.
+    const sourceName = snap.workouts[oldName]
+      ? oldName
+      : (snap.workouts[newName] ? newName : null);
     if (sourceName) {
       const newWorkouts = { ...snap.workouts };
       const existing = newWorkouts[sourceName];
-      if (isRename) delete newWorkouts[sourceName];
+      if (isRename && sourceName !== newName) delete newWorkouts[sourceName];
       newWorkouts[newName] = { ...existing, title: newName, blocks: template.blocks };
       result.workouts = newWorkouts;
     }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -64,6 +64,11 @@ function localTodayISO() {
 
 /**
  * Template lifecycle: save/rename, delete, create, syncBlocks.
+ *
+ * `save` keeps the materialized Workout consistent with the Template — an
+ * explicit save cascades the Template's blocks (including edited set targets)
+ * onto the matching Workout, mirroring the `syncBlocks` path used when a target
+ * change is confirmed from an active Session.
  */
 export function applyTemplateChange(snap, change) {
   const { type } = change;
@@ -126,14 +131,20 @@ export function applyTemplateChange(snap, change) {
         if (title === oldName) { newSchedule[date] = newName; scheduleChanged = true; }
       });
       if (scheduleChanged) result.schedule = newSchedule;
+    }
 
-      // Cascade to workouts
-      if (snap.workouts[oldName]) {
-        const newWorkouts = { ...snap.workouts };
-        delete newWorkouts[oldName];
-        newWorkouts[newName] = { ...snap.workouts[oldName], title: newName };
-        result.workouts = newWorkouts;
-      }
+    // Keep the materialized Workout consistent with the saved Template so an
+    // edited target (prescribed set) stays in sync in both directions. On a
+    // rename the workout also moves to the new key/title; either way it adopts
+    // the Template's blocks. This is the same explicit-save lifecycle path the
+    // active-Session direction uses via `syncBlocks`.
+    const sourceName = snap.workouts[oldName] ? oldName : null;
+    if (sourceName) {
+      const newWorkouts = { ...snap.workouts };
+      const existing = newWorkouts[sourceName];
+      if (isRename) delete newWorkouts[sourceName];
+      newWorkouts[newName] = { ...existing, title: newName, blocks: template.blocks };
+      result.workouts = newWorkouts;
     }
 
     return result;

--- a/src/orchestrator.test.js
+++ b/src/orchestrator.test.js
@@ -223,6 +223,81 @@ describe('applyTemplateChange — syncBlocks', () => {
   });
 });
 
+// ─── Template ⇄ Workout target consistency ──────────────
+//
+// Regression coverage for keeping prescribed-set targets consistent between a
+// Template and its materialized Workout in *both* directions, exercised through
+// the production lifecycle authority (`applyTemplateChange`).
+
+describe('applyTemplateChange — target consistency (Template ⇄ Workout)', () => {
+  const blocksWithTarget = (reps, weight) => [
+    { exercises: [{ title: 'Bench', sets: [{ reps, weight, unit: 'lb', repsUnit: 'reps' }] }] },
+  ];
+
+  const makeSnap = () => ({
+    templates: {
+      tpl_1: { id: 'tpl_1', name: 'Upper A', blocks: blocksWithTarget(8, 135) },
+    },
+    workouts: {
+      'Upper A': { title: 'Upper A', blocks: blocksWithTarget(8, 135) },
+    },
+    schedule: {},
+    logs: {},
+  });
+
+  it('Template → Workout: saving an edited target updates the materialized workout', () => {
+    const snap = makeSnap();
+    const editedTemplate = { ...snap.templates.tpl_1, blocks: blocksWithTarget(10, 155) };
+
+    const result = applyTemplateChange(snap, { type: 'save', template: editedTemplate });
+
+    // Template holds the new target...
+    expect(result.templates.tpl_1.blocks[0].exercises[0].sets[0]).toMatchObject({ reps: 10, weight: 155 });
+    // ...and the materialized workout is kept consistent with it.
+    expect(result.workouts).toBeDefined();
+    expect(result.workouts['Upper A'].blocks[0].exercises[0].sets[0]).toMatchObject({ reps: 10, weight: 155 });
+  });
+
+  it('Template → Workout: rename carries the edited target onto the renamed workout', () => {
+    const snap = makeSnap();
+    const editedTemplate = { ...snap.templates.tpl_1, name: 'Upper B', blocks: blocksWithTarget(12, 145) };
+
+    const result = applyTemplateChange(snap, {
+      type: 'save',
+      template: editedTemplate,
+      previousName: 'Upper A',
+    });
+
+    expect(result.workouts['Upper A']).toBeUndefined();
+    expect(result.workouts['Upper B'].title).toBe('Upper B');
+    expect(result.workouts['Upper B'].blocks[0].exercises[0].sets[0]).toMatchObject({ reps: 12, weight: 145 });
+  });
+
+  it('Template → Workout: save without a materialized workout omits the workouts write', () => {
+    const snap = makeSnap();
+    delete snap.workouts['Upper A'];
+    const editedTemplate = { ...snap.templates.tpl_1, blocks: blocksWithTarget(10, 155) };
+
+    const result = applyTemplateChange(snap, { type: 'save', template: editedTemplate });
+
+    expect(result.workouts).toBeUndefined();
+  });
+
+  it('Session → Template: confirming an edited target updates the matching template', () => {
+    const snap = makeSnap();
+    const confirmedBlocks = blocksWithTarget(6, 185);
+
+    const result = applyTemplateChange(snap, {
+      type: 'syncBlocks',
+      workoutTitle: 'Upper A',
+      blocks: confirmedBlocks,
+    });
+
+    expect(result.workouts['Upper A'].blocks[0].exercises[0].sets[0]).toMatchObject({ reps: 6, weight: 185 });
+    expect(result.templates.tpl_1.blocks[0].exercises[0].sets[0]).toMatchObject({ reps: 6, weight: 185 });
+  });
+});
+
 // ─── applyScheduleChange ────────────────────────────────
 
 describe('applyScheduleChange', () => {

--- a/src/orchestrator.test.js
+++ b/src/orchestrator.test.js
@@ -283,6 +283,24 @@ describe('applyTemplateChange — target consistency (Template ⇄ Workout)', ()
     expect(result.workouts).toBeUndefined();
   });
 
+  it('Template → Workout: rename refreshes a stale workout already under the new name', () => {
+    // Old key absent, but a stale materialized workout already exists under the
+    // new name (e.g. a prior schedule materialized it). Its targets must refresh.
+    const snap = makeSnap();
+    delete snap.workouts['Upper A'];
+    snap.workouts['Upper B'] = { title: 'Upper B', blocks: blocksWithTarget(8, 135) };
+    const editedTemplate = { ...snap.templates.tpl_1, name: 'Upper B', blocks: blocksWithTarget(12, 145) };
+
+    const result = applyTemplateChange(snap, {
+      type: 'save',
+      template: editedTemplate,
+      previousName: 'Upper A',
+    });
+
+    expect(result.workouts['Upper B'].title).toBe('Upper B');
+    expect(result.workouts['Upper B'].blocks[0].exercises[0].sets[0]).toMatchObject({ reps: 12, weight: 145 });
+  });
+
   it('Session → Template: confirming an edited target updates the matching template', () => {
     const snap = makeSnap();
     const confirmedBlocks = blocksWithTarget(6, 185);


### PR DESCRIPTION
## Summary

Keeps prescribed-set **targets** consistent between a **Template** and its
materialized **Workout** in both directions, through the production lifecycle
authority (`applyTemplateChange` in `src/orchestrator.js`).

- **Template → Workout:** saving a Template now cascades its `blocks` (including
  edited set targets) onto the matching materialized Workout. Previously a
  non-rename save updated only the Template, leaving the Workout's prescribed
  sets stale until the next rename or session sync.
- **Session → Template:** confirming a target change from an active Session
  already flowed back to the Template via the `syncBlocks` path; this direction
  is now covered by explicit regression tests so it can't silently break.

Closes #62

## Changes

- `src/orchestrator.js` — `applyTemplateChange` `save` case now cascades the
  saved Template's blocks onto the materialized Workout on every save (not only
  on rename); on rename it also carries the edited blocks onto the renamed
  Workout key/title. No new change type, storage key, migration, or implicit
  save is introduced — the cascade rides the existing explicit save.
- `src/orchestrator.test.js` — regression coverage for both directions through
  the production lifecycle authority (Template→Workout save + rename, no-op when
  the Workout is absent, Session→Template `syncBlocks`).
- `e2e/template-session-target-consistency.e2e.js` — end-to-end journeys driving
  the real UI in both directions.

## Acceptance criteria

- [x] Editing an Exercise target in a Template updates the matching materialized
  Workout through the lifecycle authority.
- [x] Confirming a target change from an active Session updates the matching
  Template through the same authority.
- [x] Regression tests cover both directions through the production lifecycle
  adapter.
- [x] No migration, storage-key change, or implicit target save is introduced.

## Decisions

- Interpreted "lifecycle authority / production lifecycle adapter" as the
  orchestrator's pure `applyTemplateChange` (the single function that keeps
  Templates and materialized Workouts consistent), dispatched in production via
  `applyWrites` in `App.jsx`. Regression tests exercise `applyTemplateChange`
  directly plus end-to-end journeys through the UI.
- The Template save cascade copies only `blocks` (which carry set targets),
  preserving the Workout's other fields via spread. This mirrors the existing
  `syncBlocks` reverse path and avoids scope creep (e.g. workout-level notes).
- On rename the Workout adopts the Template's edited blocks (not the stale
  pre-edit blocks) so a rename-plus-target-edit stays consistent.

## Testing

- `npm run test:unit` — 560 passed.
- `npm run test:e2e` — 86 passed, 6 skipped.
- `npm run test:e2e:visual` — 69 passed; inspected desktop + mobile PNGs.
- `npm run build` — success.

### Visual evidence inspected

- `artifacts/visual/chromium/session-target-reflects-template-edit.png`
- `artifacts/visual/mobile-chrome/session-target-reflects-template-edit.png`
- `artifacts/visual/chromium/template-target-reflects-session-confirmation.png`
- `artifacts/visual/mobile-chrome/template-target-reflects-session-confirmation.png`

Checked: session's first-set TARGET shows the Template-edited reps (`9 × BW`);
Template editor's first set shows the Session-confirmed reps (`5`); dark-theme
styling intact, no clipping/overlap, bottom nav and primary actions visible on
mobile.

## Review notes

Dual-model review (gpt-5.5 code quality/correctness + claude-opus-4.8 security), both run in parallel against this diff.

- **Adopted (gpt-5.5, Medium):** On a Template rename where the old workout key was absent but a stale materialized Workout already sat under the new name, the cascade was skipped, leaving stale targets. Fixed in `src/orchestrator.js` by falling back to `snap.workouts[newName]` as the cascade source (guarding the old-key delete with `sourceName !== newName`). Added a regression test `rename refreshes a stale workout already under the new name`.
- **Security (claude-opus-4.8): zero findings.** Confirmed no global prototype pollution (computed-key literals create own props; single-level bracket assignment reparents only the local copy), no new untrusted-input sinks, and the added tests make no live external calls and contain no secrets or personal data. The single-user offline PWA has no privilege boundary here; the pattern is pre-existing and not worsened by this diff — out of scope for this slice.
- No cosmetic/low-value findings were set aside.

