### PR TITLE
feat: duplicate Templates through the Training Plan lifecycle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,7 +58,6 @@ export default function App() {
     templates,
     templateList,
     saveTemplates,
-    duplicateTemplate,
   } = useTemplates();
   const { syncStatus, lastSynced, pullSync, pushSync } = useSync();
   const showToast = useToast();
@@ -75,6 +74,13 @@ export default function App() {
 
   const handleDeleteTemplate = (id) =>
     applyWrites(applyTemplateChange(snap(), { type: 'delete', templateId: id }));
+
+  // Duplicate is a Training Plan lifecycle intention, not a direct write: the
+  // orchestrator deep-clones the Template and applies the same collision
+  // handling as create/rename. Returns the applyWrites boolean so callers can
+  // suppress a success toast when the copy was rejected.
+  const handleDuplicateTemplate = (id) =>
+    applyWrites(applyTemplateChange(snap(), { type: 'duplicate', templateId: id }));
 
   // Navigation state — after a sync-triggered reload, always land on Training
   const [navState, setNavState] = useState(() => {
@@ -276,7 +282,7 @@ export default function App() {
     templateList,
     deleteTemplate: handleDeleteTemplate,
     renameTemplate: handleRenameTemplate,
-    duplicateTemplate,
+    duplicateTemplate: handleDuplicateTemplate,
     navigate,
     onClearAllData: handleClearAllData,
     syncStatus,

--- a/src/hooks/useTemplates.js
+++ b/src/hooks/useTemplates.js
@@ -26,20 +26,6 @@ export function useTemplates() {
     saveTemplates({ ...templates, [id]: { ...templates[id], name: newName } });
   }, [templates, saveTemplates]);
 
-  const duplicateTemplate = useCallback((id) => {
-    if (!templates[id]) return;
-    const original = templates[id];
-    const newId = `tpl_${Date.now()}`;
-    const copy = {
-      ...original,
-      id: newId,
-      name: `${original.name} (Copy)`,
-      createdDate: new Date().toISOString(),
-    };
-    saveTemplate(newId, copy);
-    return newId;
-  }, [templates, saveTemplate]);
-
   const createTemplateFromWorkout = useCallback((workout) => {
     const id = `tpl_${Date.now()}`;
     const template = {
@@ -65,7 +51,6 @@ export function useTemplates() {
     saveTemplate,
     deleteTemplate,
     renameTemplate,
-    duplicateTemplate,
     createTemplateFromWorkout,
   };
 }

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -40,6 +40,15 @@ function findTemplateByName(templates, name) {
   return Object.values(templates).find((t) => t.name === name);
 }
 
+// Deep, reference-free copy of a JSON-serializable value so a duplicated
+// Template shares no nested objects (Parts, Exercises, Sets, notes) with its
+// source. `structuredClone` is available in supported browsers and Node ≥17;
+// the JSON round-trip is a defensive fallback for older runtimes.
+function deepClone(value) {
+  if (typeof structuredClone === 'function') return structuredClone(value);
+  return JSON.parse(JSON.stringify(value));
+}
+
 // A completed Log is keyed `YYYY-MM-DD::WorkoutTitle`. Workout titles may
 // themselves contain `::`, so match on the exact title after the first
 // separator rather than a naive suffix check.
@@ -167,6 +176,28 @@ export function applyTemplateChange(snap, change) {
       notes: workout.notes || '',
     };
     return { templates: { ...snap.templates, [id]: tpl }, meta: { createdId: id } };
+  }
+
+  if (type === 'duplicate') {
+    const { templateId, makeId } = change;
+    const original = snap.templates[templateId];
+    if (!original) return { error: 'Template not found' };
+
+    // Consistent collision handling: a copy is named "<name> (Copy)". If that
+    // name is already taken, reject with the exact same outcome as create and
+    // rename rather than silently minting a colliding Template.
+    const name = `${original.name} (Copy)`;
+    if (hasNameCollision(snap.templates, name)) {
+      return { error: 'A template with this name already exists' };
+    }
+
+    const id = makeId ? makeId() : `tpl_${Date.now()}`;
+    const copy = deepClone(original);
+    copy.id = id;
+    copy.name = name;
+    copy.createdDate = new Date().toISOString();
+
+    return { templates: { ...snap.templates, [id]: copy }, meta: { createdId: id } };
   }
 
   if (type === 'syncBlocks') {

--- a/src/orchestrator.test.js
+++ b/src/orchestrator.test.js
@@ -202,6 +202,126 @@ describe('applyTemplateChange — create', () => {
   });
 });
 
+// ─── applyTemplateChange: duplicate ─────────────────────
+
+describe('applyTemplateChange — duplicate', () => {
+  const richTemplate = {
+    id: 'tpl_1',
+    name: 'Upper A',
+    createdDate: '2026-01-01T00:00:00.000Z',
+    notes: 'Push day focus',
+    blocks: [
+      {
+        exercises: [
+          {
+            title: 'Bench',
+            notes: 'Keep elbows tight',
+            workoutNotes: '8 reps each set',
+            sets: [{ reps: 8, weight: 135 }, { reps: 8, weight: 135 }],
+          },
+        ],
+      },
+    ],
+  };
+
+  const baseSnap = {
+    templates: { tpl_1: richTemplate },
+    workouts: {},
+    schedule: {},
+    logs: {},
+  };
+
+  it('creates an independent copy named "<name> (Copy)"', () => {
+    const result = applyTemplateChange(baseSnap, {
+      type: 'duplicate',
+      templateId: 'tpl_1',
+      makeId: () => 'tpl_copy',
+    });
+    expect(result.error).toBeUndefined();
+    const copy = result.templates.tpl_copy;
+    expect(copy).toBeDefined();
+    expect(copy.id).toBe('tpl_copy');
+    expect(copy.name).toBe('Upper A (Copy)');
+    // Original is left untouched.
+    expect(result.templates.tpl_1).toBe(richTemplate);
+    expect(result.meta.createdId).toBe('tpl_copy');
+  });
+
+  it('returns an error for a missing template', () => {
+    const result = applyTemplateChange(baseSnap, {
+      type: 'duplicate',
+      templateId: 'nope',
+    });
+    expect(result.error).toBeDefined();
+    expect(result.templates).toBeUndefined();
+  });
+
+  it('deep-clones parts, exercises, sets, and notes (no shared references)', () => {
+    const result = applyTemplateChange(baseSnap, {
+      type: 'duplicate',
+      templateId: 'tpl_1',
+      makeId: () => 'tpl_copy',
+    });
+    const copy = result.templates.tpl_copy;
+    // Structural equality of the training content...
+    expect(copy.blocks).toEqual(richTemplate.blocks);
+    // ...but no shared object references at any depth.
+    expect(copy.blocks).not.toBe(richTemplate.blocks);
+    expect(copy.blocks[0]).not.toBe(richTemplate.blocks[0]);
+    expect(copy.blocks[0].exercises).not.toBe(richTemplate.blocks[0].exercises);
+    expect(copy.blocks[0].exercises[0]).not.toBe(richTemplate.blocks[0].exercises[0]);
+    expect(copy.blocks[0].exercises[0].sets).not.toBe(richTemplate.blocks[0].exercises[0].sets);
+    expect(copy.blocks[0].exercises[0].sets[0]).not.toBe(richTemplate.blocks[0].exercises[0].sets[0]);
+  });
+
+  it('keeps the copy independent after editing it (mutating the clone does not affect the original)', () => {
+    const result = applyTemplateChange(baseSnap, {
+      type: 'duplicate',
+      templateId: 'tpl_1',
+      makeId: () => 'tpl_copy',
+    });
+    const copy = result.templates.tpl_copy;
+    copy.blocks[0].exercises[0].sets[0].weight = 999;
+    copy.blocks[0].exercises[0].notes = 'changed';
+    expect(richTemplate.blocks[0].exercises[0].sets[0].weight).toBe(135);
+    expect(richTemplate.blocks[0].exercises[0].notes).toBe('Keep elbows tight');
+  });
+
+  it('duplicates a copy, producing a valid available nested name', () => {
+    const snap = {
+      ...baseSnap,
+      templates: {
+        tpl_1: richTemplate,
+        tpl_copy: { ...richTemplate, id: 'tpl_copy', name: 'Upper A (Copy)' },
+      },
+    };
+    const result = applyTemplateChange(snap, {
+      type: 'duplicate',
+      templateId: 'tpl_copy',
+      makeId: () => 'tpl_copy2',
+    });
+    expect(result.error).toBeUndefined();
+    expect(result.templates.tpl_copy2.name).toBe('Upper A (Copy) (Copy)');
+  });
+
+  it('rejects on collision with the same outcome as create/rename (case-insensitive)', () => {
+    const snap = {
+      ...baseSnap,
+      templates: {
+        tpl_1: richTemplate,
+        tpl_existing: { id: 'tpl_existing', name: 'upper a (copy)', blocks: [] },
+      },
+    };
+    const result = applyTemplateChange(snap, {
+      type: 'duplicate',
+      templateId: 'tpl_1',
+      makeId: () => 'tpl_copy',
+    });
+    expect(result.error).toMatch(/already exists/i);
+    expect(result.templates).toBeUndefined();
+  });
+});
+
 // ─── applyTemplateChange: syncBlocks ────────────────────
 
 describe('applyTemplateChange — syncBlocks', () => {

--- a/src/views/SettingsView.jsx
+++ b/src/views/SettingsView.jsx
@@ -152,8 +152,9 @@ export default function SettingsView({
   };
 
   const handleDuplicate = (id) => {
-    duplicateTemplate(id);
-    showToast('Template duplicated');
+    if (duplicateTemplate(id)) {
+      showToast('Template duplicated');
+    }
   };
 
   // Storage usage via quota module


### PR DESCRIPTION
## Summary

An athlete can duplicate a Template — including a copy of a copy — and receive an independent, reusable Template with consistent collision handling.

Duplication is now a **Training Plan lifecycle intention** rather than a direct persistence write: it flows through `applyTemplateChange(snap, { type: 'duplicate', templateId })` in `src/orchestrator.js`, the same pure-function authority that owns create, rename, delete, and syncBlocks.

Closes #59

## What changed

- **`src/orchestrator.js`** — new `type: 'duplicate'` branch in `applyTemplateChange`. It deep-clones the source Template (new `deepClone` helper) so the copy shares no nested objects across Parts, Exercises, Sets, and notes; names the copy `"<name> (Copy)"`; and reuses the existing `hasNameCollision` check to return the exact same `'A template with this name already exists'` error as create/rename when that name is taken. Returns `meta.createdId`, mirroring `create`.
- **`src/hooks/useTemplates.js`** — removed the old `duplicateTemplate` direct-write (and its export). The hook no longer performs duplication persistence itself.
- **`src/App.jsx`** — added `handleDuplicateTemplate` that dispatches the `duplicate` intention through the shared `applyWrites` dispatcher and passes it to `SettingsView` as `duplicateTemplate`.
- **`src/views/SettingsView.jsx`** — `handleDuplicate` now only shows the "Template duplicated" toast when the write succeeds; on collision, `applyWrites` surfaces the error toast (no more contradictory double toast).
- **`src/orchestrator.test.js`** — six new tests (see below).

No persisted shape changes: the copy keeps the existing `{ id, name, createdDate, blocks, notes }` template shape.

## Tests

New `applyTemplateChange — duplicate` suite covers:
- independent copy named `"<name> (Copy)"` with a fresh id, original left untouched;
- error for a missing template;
- deep clone with no shared references at any depth (blocks → exercises → sets);
- independence after edits (mutating the clone does not affect the source);
- **copying a copy** → valid available nested name `"... (Copy) (Copy)"`;
- **collision rejection** → same case-insensitive `already exists` error as create/rename.

Validation (all green):
- `npm run test:unit` — 567 passed
- `npm run test:e2e` — 86 passed, 6 skipped
- `npm run build` — succeeds

## Decisions

- **Naming/collision scheme.** Deterministic `"<name> (Copy)"` rather than an auto-incrementing counter. This satisfies both halves of the acceptance criterion cleanly: duplicating a distinct source (or a copy) yields a valid available name, while duplicating the same source again — when its `(Copy)` already exists — returns the *same* collision outcome as create and rename. It keeps collision handling identical across all three lifecycle paths.
- **No new UI button.** The current `TemplateListView` does not render a duplicate control (only delete via swipe); the `duplicateTemplate` prop was already plumbed App → SettingsView but not surfaced. This slice rewires that existing path through the lifecycle rather than introducing a new user-visible control, so no UI surface changed. Visual screenshot evidence is therefore not applicable; behavior is proven by the unit suite and the unchanged, still-green e2e suite.

## Review notes

Dual-model code review ran on this PR (parallel `code-review` agents):
- **gpt-5.5 — code quality & correctness:** no significant issues found.
- **claude-opus-4.8 — security:** no security issues found. Explicitly cleared prototype-pollution (keys are always generated ids, never user input; `deepClone` uses `structuredClone`/JSON round-trip with no reviver), injection, ReDoS, unsafe deserialization, and DoS vectors.

No fix commits were required.
