### PR TITLE
feat: observe committed Training Plan snapshot across back-to-back actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import { useSync } from './hooks/useSync';
 import { retryReplication, clearByKeys, coordinateSyncReload } from './storage/authority';
 import { useToast } from './components/Toast';
 import { applyTemplateChange, applyScheduleChange, applyNoteChange, applyImport } from './orchestrator';
+import { useTrainingPlanShell } from './hooks/useTrainingPlanShell';
 import {
   ROUTE_IMPORT,
   ROUTE_TRAINING,
@@ -62,15 +63,15 @@ export default function App() {
   const { syncStatus, lastSynced, pullSync, pushSync } = useSync();
   const showToast = useToast();
 
-  // Orchestration: snapshot builder + write dispatcher
-  const snap = () => ({ templates, workouts, schedule, logs });
-  const applyWrites = (result) => {
-    if (result.error) { showToast(result.error, 'error'); return false; }
-    if (result.templates !== undefined) saveTemplates(result.templates);
-    if (result.workouts !== undefined) saveWorkouts(result.workouts);
-    if (result.schedule !== undefined) saveSchedule(result.schedule);
-    return true;
-  };
+  // Orchestration: the shell owns the latest committed Training Plan snapshot so
+  // back-to-back planning actions build on prior committed writes rather than a
+  // stale render snapshot. snap() reads committed state; applyWrites commits and
+  // advances it (and surfaces rejections as a toast without mutating state).
+  const { snap, applyWrites } = useTrainingPlanShell({
+    state: { templates, workouts, schedule, logs },
+    writers: { saveTemplates, saveWorkouts, saveSchedule },
+    onError: (message) => showToast(message, 'error'),
+  });
 
   const handleDeleteTemplate = (id) =>
     applyWrites(applyTemplateChange(snap(), { type: 'delete', templateId: id }));

--- a/src/hooks/useTrainingPlanShell.js
+++ b/src/hooks/useTrainingPlanShell.js
@@ -1,0 +1,69 @@
+import { useRef } from 'react';
+
+/**
+ * Training Plan shell — owns the latest *committed* snapshot that lifecycle
+ * actions read from, and dispatches orchestrator results to the entity writers.
+ *
+ * Why this exists: the orchestrator functions are pure `(snapshot, …) → result`,
+ * but React render state lags behind synchronous writes. Two planning actions
+ * fired back-to-back in one tick both read the same render-time snapshot, so the
+ * second silently overwrites the first's committed change. This hook keeps a ref
+ * to the latest committed snapshot and advances it immediately after every
+ * successful write, so sequential actions build on prior committed state.
+ *
+ * @param {object}   args
+ * @param {object}   args.state    Current render snapshot: { templates, workouts, schedule, logs }.
+ * @param {object}   args.writers  { saveTemplates, saveWorkouts, saveSchedule } commit functions.
+ * @param {function} [args.onError] Called with the error message when a result is rejected.
+ * @returns {{ snap: () => object, applyWrites: (result: object) => boolean }}
+ */
+export function useTrainingPlanShell({ state, writers, onError }) {
+  const { templates, workouts, schedule, logs } = state;
+
+  const committedRef = useRef({ templates, workouts, schedule, logs });
+
+  // Keep the committed snapshot aligned with the latest render so external
+  // updates (sync pulls, logging, restore) are observed by the next action.
+  // Advances made between renders survive because React re-renders with state
+  // that already includes them, so this only ever syncs forward.
+  const current = committedRef.current;
+  if (
+    current.templates !== templates ||
+    current.workouts !== workouts ||
+    current.schedule !== schedule ||
+    current.logs !== logs
+  ) {
+    committedRef.current = { templates, workouts, schedule, logs };
+  }
+
+  const snap = () => committedRef.current;
+
+  const applyWrites = (result) => {
+    // A rejected action must leave committed state fully intact — no partial
+    // snapshot is committed or exposed to the next action.
+    if (result.error) {
+      if (onError) onError(result.error);
+      return false;
+    }
+
+    const next = { ...committedRef.current };
+    if (result.templates !== undefined) {
+      writers.saveTemplates(result.templates);
+      next.templates = result.templates;
+    }
+    if (result.workouts !== undefined) {
+      writers.saveWorkouts(result.workouts);
+      next.workouts = result.workouts;
+    }
+    if (result.schedule !== undefined) {
+      writers.saveSchedule(result.schedule);
+      next.schedule = result.schedule;
+    }
+
+    // Advance atomically only after all writers succeeded.
+    committedRef.current = next;
+    return true;
+  };
+
+  return { snap, applyWrites };
+}

--- a/src/hooks/useTrainingPlanShell.test.jsx
+++ b/src/hooks/useTrainingPlanShell.test.jsx
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { useState, useRef } from 'react';
+import { renderHook, act } from '@testing-library/react';
+
+import { useTrainingPlanShell } from './useTrainingPlanShell';
+import { applyTemplateChange, applyScheduleChange } from '../orchestrator';
+
+// Harness mirrors the App.jsx shell-to-lifecycle path: render state lives in
+// React, writers commit through setState (as the entity hooks do), and every
+// planning action reads snap() before calling the real orchestrator.
+function useHarness(initial) {
+  const [templates, setTemplates] = useState(initial.templates || {});
+  const [workouts, setWorkouts] = useState(initial.workouts || {});
+  const [schedule, setSchedule] = useState(initial.schedule || {});
+  const [logs] = useState(initial.logs || {});
+  const errors = useRef([]);
+
+  const shell = useTrainingPlanShell({
+    state: { templates, workouts, schedule, logs },
+    writers: {
+      saveTemplates: setTemplates,
+      saveWorkouts: setWorkouts,
+      saveSchedule: setSchedule,
+    },
+    onError: (message) => errors.current.push(message),
+  });
+
+  return { shell, state: { templates, workouts, schedule, logs }, errors };
+}
+
+const createChange = (title, id) => ({
+  type: 'create',
+  workout: { title, blocks: [], notes: '' },
+  makeId: () => id,
+});
+
+describe('useTrainingPlanShell — committed Training Plan snapshot', () => {
+  it('advances the committed snapshot so a single action is reflected immediately', () => {
+    const { result } = renderHook(() => useHarness({}));
+
+    act(() => {
+      const { shell } = result.current;
+      shell.applyWrites(applyScheduleChange(shell.snap(), { '2026-01-01': 'Upper A' }));
+    });
+
+    expect(result.current.shell.snap().schedule).toEqual({ '2026-01-01': 'Upper A' });
+    expect(result.current.state.schedule).toEqual({ '2026-01-01': 'Upper A' });
+  });
+
+  it('lets back-to-back actions observe the prior committed change instead of a stale render snapshot', () => {
+    const { result } = renderHook(() => useHarness({}));
+
+    // Two synchronous actions in one tick — the second must see the first's
+    // committed template, not the render-time (empty) snapshot.
+    act(() => {
+      const { shell } = result.current;
+      shell.applyWrites(applyTemplateChange(shell.snap(), createChange('Upper A', 'idA')));
+      shell.applyWrites(applyTemplateChange(shell.snap(), createChange('Lower B', 'idB')));
+    });
+
+    const committed = result.current.shell.snap().templates;
+    expect(Object.keys(committed).sort()).toEqual(['idA', 'idB']);
+    // Committed React state must also carry both — the first write is not lost.
+    expect(Object.keys(result.current.state.templates).sort()).toEqual(['idA', 'idB']);
+  });
+
+  it('matches explicitly applying the second action to the first action result', () => {
+    const { result } = renderHook(() => useHarness({}));
+
+    // Independent source of truth: fold the two actions by hand.
+    const afterA = applyTemplateChange({ templates: {}, workouts: {}, schedule: {}, logs: {} }, createChange('Upper A', 'idA'));
+    const expected = applyTemplateChange(
+      { templates: afterA.templates, workouts: {}, schedule: {}, logs: {} },
+      createChange('Lower B', 'idB')
+    );
+
+    act(() => {
+      const { shell } = result.current;
+      shell.applyWrites(applyTemplateChange(shell.snap(), createChange('Upper A', 'idA')));
+      shell.applyWrites(applyTemplateChange(shell.snap(), createChange('Lower B', 'idB')));
+    });
+
+    expect(result.current.shell.snap().templates).toEqual(expected.templates);
+  });
+
+  it('leaves committed state intact when an action is rejected and never exposes a partial snapshot', () => {
+    const { result } = renderHook(() => useHarness({}));
+
+    let secondOk;
+    act(() => {
+      const { shell } = result.current;
+      shell.applyWrites(applyTemplateChange(shell.snap(), createChange('Upper A', 'idA')));
+      // Colliding name — orchestrator returns { error }, applyWrites must reject.
+      secondOk = shell.applyWrites(applyTemplateChange(shell.snap(), createChange('Upper A', 'idDup')));
+    });
+
+    expect(secondOk).toBe(false);
+    expect(result.current.errors.current).toHaveLength(1);
+    // Committed snapshot is exactly the post-A state — no idDup leaked in.
+    expect(Object.keys(result.current.shell.snap().templates)).toEqual(['idA']);
+
+    // A follow-up action still sees the intact committed state from action A.
+    act(() => {
+      const { shell } = result.current;
+      shell.applyWrites(applyTemplateChange(shell.snap(), createChange('Lower B', 'idB')));
+    });
+
+    expect(Object.keys(result.current.shell.snap().templates).sort()).toEqual(['idA', 'idB']);
+  });
+
+  it('picks up external render-state changes so committed reflects the latest render', () => {
+    const { result, rerender } = renderHook((props) => useHarness(props), {
+      initialProps: {},
+    });
+
+    // Simulate an external commit (e.g. a sync pull) by re-rendering with new
+    // schedule state; the next action must build on that, not a stale snapshot.
+    act(() => {
+      const { shell } = result.current;
+      shell.applyWrites(applyScheduleChange(shell.snap(), { '2026-01-01': 'Upper A' }));
+    });
+
+    act(() => {
+      const { shell } = result.current;
+      shell.applyWrites(applyScheduleChange(shell.snap(), { '2026-01-02': 'Lower B' }));
+    });
+
+    expect(result.current.shell.snap().schedule).toEqual({
+      '2026-01-01': 'Upper A',
+      '2026-01-02': 'Lower B',
+    });
+  });
+});

--- a/src/hooks/useTrainingPlanShell.test.jsx
+++ b/src/hooks/useTrainingPlanShell.test.jsx
@@ -81,7 +81,18 @@ describe('useTrainingPlanShell — committed Training Plan snapshot', () => {
       shell.applyWrites(applyTemplateChange(shell.snap(), createChange('Lower B', 'idB')));
     });
 
-    expect(result.current.shell.snap().templates).toEqual(expected.templates);
+    // Compare structure without the per-call `createdDate` timestamp, which the
+    // orchestrator stamps from `new Date()` on each invocation and can differ by
+    // a millisecond between the hand-folded expectation and the shell's writes.
+    const stripDates = (templates) =>
+      Object.fromEntries(
+        Object.entries(templates).map(([id, t]) => {
+          const { createdDate, ...rest } = t;
+          return [id, rest];
+        })
+      );
+
+    expect(stripDates(result.current.shell.snap().templates)).toEqual(stripDates(expected.templates));
   });
 
   it('leaves committed state intact when an action is rejected and never exposes a partial snapshot', () => {


### PR DESCRIPTION
## Summary

Back-to-back Training Plan actions previously read the same render-time snapshot, so the second action silently overwrote the first action's committed change (the orchestrator functions are pure `(snapshot, …) → result`, but React render state lags synchronous writes).

This extracts the App shell's snapshot/dispatch into a new `useTrainingPlanShell` hook that:

- Owns the latest **committed** Training Plan snapshot in a ref and **advances it immediately** after each successful lifecycle write, so sequential actions build on prior committed state.
- Keeps the committed snapshot aligned with the latest render (external updates like sync pulls / restore are still observed).
- On a **rejected** result (`{ error }`), surfaces the toast and returns `false` **without** mutating or advancing committed state — no partial snapshot is ever exposed to the next action.

`App.jsx` now consumes the hook in place of its inline `snap()`/`applyWrites`, so this is the real production shell-to-lifecycle path.

## Acceptance criteria

- [x] Keeps and immediately advances a latest committed Training Plan snapshot after successful lifecycle writes.
- [x] Back-to-back actions produce the same result as explicitly applying the second to the first action's result (covered by dedicated test).
- [x] A rejected action leaves committed state intact and cannot expose a partial snapshot.
- [x] Existing individual planning actions remain unchanged (single-action test + full suite green).
- [x] Regression coverage exercises the production shell-to-lifecycle path (`useTrainingPlanShell` is the exact code App renders; test drives it with React state + the real orchestrator).

## Tests

- `npm run test:unit` — 573 passing (new `src/hooks/useTrainingPlanShell.test.jsx`, 5 cases).
- `npm run test:e2e` — 86 passing / 6 skipped.
- `npm run build` — succeeds.

## Decisions

- **Extracted a hook rather than inlining a ref in App.jsx.** The shell wiring becomes directly testable via `renderHook` using the same code path production renders, matching the repo's existing pattern of a single wired lifecycle (`src/orchestrator.js`) with a thin shell. It does not reintroduce the retired `operations`/`useDataLayer` path.
- **Render-body ref sync (identity-compared) rather than `useEffect`.** Advances made between renders survive because React re-renders with state that already includes them, so the sync only moves forward and never clobbers an in-tick advance.

## Visual verification

No user-visible/UI change — this is a data-integrity fix in the shell dispatch layer with no rendered difference, so screenshot evidence is not applicable. Verified via the e2e suite (planning/template journeys remain green).

## Review notes

Dual-model review run (2 parallel `code-review` agents on the PR diff):

- **gpt-5.5 (code quality & correctness):** One valid finding — the "matches explicitly applying the second action" test compared full template objects including `createdDate`, which the orchestrator stamps from `new Date()` per call and can differ by ~1ms between the hand-folded expectation and the shell's writes (timing-sensitive). **Adopted:** the test now compares template structure with the volatile `createdDate` stripped from both sides, preserving the folding assertion. No other correctness findings; the render-body identity sync and advance-only-on-success semantics were confirmed sound under React 18 batching.
- **claude-opus-4.8 (security):** No findings. Confirmed no prototype-pollution vector (only hardcoded literal keys are read/written; no data-derived bracket assignment), no secrets/PII logging, and no injection/SSRF/path-traversal/crypto surface touched.

Closes #60

