### PR TITLE
feat: start and resume active Sessions through the Session module

### DIFF
--- a/e2e/session-resume.e2e.js
+++ b/e2e/session-resume.e2e.js
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test';
+import {
+  captureVisualEvidence,
+  completeNextSet,
+  expectBottomNavVisible,
+  gotoCleanApp,
+  importSampleCsv,
+  quickStartLowerBodyWorkout,
+} from './helpers';
+
+// Simulates a crash: an active Session is left in localStorage mid-Workout,
+// then the PWA is reloaded. The Session module drives the resume decision.
+
+test('resumes an unfinished Session with completed Sets and start time intact', async ({ page }) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+  await quickStartLowerBodyWorkout(page);
+
+  // Log one Set, then "crash" by reloading before completing the Workout.
+  await completeNextSet(page);
+  await expect(page.getByRole('button', { name: 'Finish (1/7 sets)' })).toBeVisible();
+
+  await page.reload();
+
+  // The Session module classifies this as a valid unfinished Session -> prompt.
+  const resumeModal = page.getByRole('heading', { name: 'Resume Workout?' });
+  await expect(resumeModal).toBeVisible();
+  await expect(page.locator('.modal').getByText('Lower Body B')).toBeVisible();
+  await expect(page.getByText('1 of 7 sets completed')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Resume' }).click();
+
+  // The recovered Session restores the completed Set (1/7), not a fresh start.
+  await expect(page.getByRole('button', { name: 'Finish (1/7 sets)' })).toBeVisible();
+});
+
+test('@visual resume prompt appears after a mid-Session reload', async ({ page }, testInfo) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+  await quickStartLowerBodyWorkout(page);
+
+  await completeNextSet(page);
+  await expect(page.getByRole('button', { name: 'Finish (1/7 sets)' })).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByRole('heading', { name: 'Resume Workout?' })).toBeVisible();
+  await expect(page.getByText('1 of 7 sets completed')).toBeVisible();
+
+  await captureVisualEvidence(page, testInfo, 'session-resume-prompt');
+});
+
+test('discarding an unfinished Session clears it and returns to Training', async ({ page }) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+  await quickStartLowerBodyWorkout(page);
+
+  await completeNextSet(page);
+  await page.reload();
+  await expect(page.getByRole('heading', { name: 'Resume Workout?' })).toBeVisible();
+
+  await page.getByRole('button', { name: 'Discard' }).click();
+
+  // Back on Training with the nav visible, and no lingering active Session.
+  await expect(page.getByRole('heading', { name: /Good (morning|afternoon|evening)/ })).toBeVisible();
+  await expectBottomNavVisible(page);
+
+  await page.reload();
+  await expect(page.getByRole('heading', { name: 'Resume Workout?' })).toHaveCount(0);
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,6 +23,7 @@ import {
   ROUTE_STATS,
   parseLogKey,
 } from './constants';
+import { evaluateSessionRecovery } from './session/session';
 
 import ImportView from './views/ImportView';
 import TrainingView from './views/TrainingView';
@@ -147,38 +148,21 @@ export default function App() {
   // Check for crash recovery on mount
   useEffect(() => {
     if (session && Object.keys(workouts).length > 0) {
-      try {
-        const { date, workoutTitle } = parseLogKey(session.logKey);
-
-        // Discard sessions older than 7 days
-        const sessionDate = new Date(date + 'T00:00:00');
-        const diffDays = (Date.now() - sessionDate.getTime()) / (1000 * 60 * 60 * 24);
-        if (isNaN(diffDays) || diffDays > 7) {
-          clearSession();
-          return;
+      const { date, workoutTitle } = (() => {
+        try {
+          return parseLogKey(session.logKey);
+        } catch {
+          return {};
         }
-
-        // Don't offer resume if the log is already completed
-        const existingLog = getLog(session.logKey);
-        if (existingLog && existingLog.completedAt) {
-          clearSession();
-          return;
-        }
-
-        const w = workouts[workoutTitle];
-        const isValid =
-          w &&
-          Array.isArray(w.blocks) &&
-          w.blocks.length > 0 &&
-          w.blocks.some((b) => Array.isArray(b.exercises) && b.exercises.length > 0);
-        if (isValid) {
-          setShowResumeModal(true);
-        } else {
-          // Workout was deleted or is malformed — discard the orphaned session
-          clearSession();
-        }
-      } catch {
-        // logKey is unparseable — discard
+      })();
+      const decision = evaluateSessionRecovery({
+        session,
+        workout: workoutTitle ? workouts[workoutTitle] : undefined,
+        existingLog: date ? getLog(session.logKey) : null,
+      });
+      if (decision.action === 'resume') {
+        setShowResumeModal(true);
+      } else {
         clearSession();
       }
     }

--- a/src/session/session.js
+++ b/src/session/session.js
@@ -1,0 +1,136 @@
+import { parseLogKey } from '../constants';
+
+/**
+ * Session logging module — owns the deterministic parts of starting and
+ * recovering an active Workout Session. These functions are pure so the
+ * Session state machine can be exercised without rendering the view.
+ *
+ * Domain vocabulary (see CLAUDE.md):
+ *  - Session/Log: a completed or in-progress instance of a Workout on a date.
+ *  - Set: one prescribed round of an Exercise (target reps + weight + unit).
+ *  - Part (`block` in code): a section of a Workout holding one or more Exercises.
+ */
+
+// Active Sessions older than this many days are treated as stale and discarded.
+export const SESSION_MAX_AGE_DAYS = 7;
+
+/**
+ * Build the prescribed Set targets map for a Workout: exerciseTitle -> Set[].
+ * Each entry mirrors the prescribed reps/weight/unit and starts uncompleted.
+ */
+export function buildSessionExercises(workout) {
+  const exercises = {};
+  if (!workout || !Array.isArray(workout.blocks)) return exercises;
+
+  for (const block of workout.blocks) {
+    if (!block || !Array.isArray(block.exercises)) continue;
+    for (const exercise of block.exercises) {
+      const sets = Array.isArray(exercise.sets) ? exercise.sets : [];
+      exercises[exercise.title] = sets.map((set, setIdx) => ({
+        setIndex: setIdx,
+        targetReps: set.reps,
+        targetWeight: set.weight,
+        unit: set.unit || exercise.unit || 'lb',
+        actualReps: '',
+        actualWeight: '',
+        completed: false,
+      }));
+    }
+  }
+
+  return exercises;
+}
+
+/**
+ * Build the initial Session Log for a freshly started Workout: correct identity
+ * (logKey/workoutTitle/date), an open completion state, the original start time,
+ * and every prescribed Set initialized with its target reps, weight, and unit.
+ */
+export function buildInitialSessionLog({ logKey, workout, startedAt }) {
+  const { date, workoutTitle } = parseLogKey(logKey);
+  return {
+    logKey,
+    workoutTitle,
+    date,
+    completedAt: null,
+    startedAt: startedAt || new Date().toISOString(),
+    exercises: buildSessionExercises(workout),
+    exerciseNotes: {},
+    workoutNote: '',
+  };
+}
+
+/**
+ * Whether a Log already holds athlete-entered performance (a completed Set or a
+ * non-empty actual reps/weight). Used to avoid re-initializing prescribed
+ * targets over recovered crash data.
+ */
+export function hasLoggedData(log) {
+  if (!log || !log.exercises || typeof log.exercises !== 'object') return false;
+  return Object.values(log.exercises).some(
+    (sets) =>
+      Array.isArray(sets) &&
+      sets.some(
+        (s) =>
+          s.completed ||
+          (s.actualReps !== undefined && s.actualReps !== '') ||
+          (s.actualWeight !== undefined && s.actualWeight !== '')
+      )
+  );
+}
+
+/**
+ * A Workout is valid (resumable) when it has at least one Part containing at
+ * least one Exercise.
+ */
+export function isValidWorkout(workout) {
+  return !!(
+    workout &&
+    Array.isArray(workout.blocks) &&
+    workout.blocks.length > 0 &&
+    workout.blocks.some((b) => b && Array.isArray(b.exercises) && b.exercises.length > 0)
+  );
+}
+
+/**
+ * Decide whether a persisted active Session should be resumed or silently
+ * discarded. Discards stale (> maxAgeDays), unparseable, already-completed, and
+ * invalid-Workout Sessions without prompting the athlete.
+ *
+ * @returns {{ action: 'resume'|'discard', reason?: string, workoutTitle?: string, date?: string }}
+ */
+export function evaluateSessionRecovery({
+  session,
+  workout,
+  existingLog,
+  now = Date.now(),
+  maxAgeDays = SESSION_MAX_AGE_DAYS,
+}) {
+  if (!session || !session.logKey) {
+    return { action: 'discard', reason: 'no-session' };
+  }
+
+  let date;
+  let workoutTitle;
+  try {
+    ({ date, workoutTitle } = parseLogKey(session.logKey));
+  } catch {
+    return { action: 'discard', reason: 'unparseable' };
+  }
+
+  const sessionDate = new Date(`${date}T00:00:00`);
+  const diffDays = (now - sessionDate.getTime()) / (1000 * 60 * 60 * 24);
+  if (Number.isNaN(diffDays) || diffDays > maxAgeDays) {
+    return { action: 'discard', reason: 'stale' };
+  }
+
+  if (existingLog && existingLog.completedAt) {
+    return { action: 'discard', reason: 'completed' };
+  }
+
+  if (!isValidWorkout(workout)) {
+    return { action: 'discard', reason: 'invalid-workout' };
+  }
+
+  return { action: 'resume', workoutTitle, date };
+}

--- a/src/session/session.test.js
+++ b/src/session/session.test.js
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SESSION_MAX_AGE_DAYS,
+  buildSessionExercises,
+  buildInitialSessionLog,
+  hasLoggedData,
+  isValidWorkout,
+  evaluateSessionRecovery,
+} from './session.js';
+
+const workout = {
+  blocks: [
+    {
+      exercises: [
+        {
+          title: 'Back Squat',
+          unit: 'lb',
+          sets: [
+            { reps: 5, weight: 135 },
+            { reps: 5, weight: 155 },
+          ],
+        },
+      ],
+    },
+    {
+      exercises: [
+        {
+          title: 'Pull-Up',
+          sets: [{ reps: 8, weight: 'BW', unit: 'reps' }],
+        },
+        {
+          title: 'Dip',
+          sets: [{ reps: 10, weight: 0 }],
+        },
+      ],
+    },
+  ],
+};
+
+describe('buildSessionExercises', () => {
+  it('creates one prescribed-target entry per set with reps, weight, and unit', () => {
+    const exercises = buildSessionExercises(workout);
+
+    expect(Object.keys(exercises)).toEqual(['Back Squat', 'Pull-Up', 'Dip']);
+    expect(exercises['Back Squat']).toEqual([
+      { setIndex: 0, targetReps: 5, targetWeight: 135, unit: 'lb', actualReps: '', actualWeight: '', completed: false },
+      { setIndex: 1, targetReps: 5, targetWeight: 155, unit: 'lb', actualReps: '', actualWeight: '', completed: false },
+    ]);
+  });
+
+  it('prefers the set unit, then the exercise unit, then defaults to lb', () => {
+    const exercises = buildSessionExercises(workout);
+    expect(exercises['Pull-Up'][0].unit).toBe('reps'); // set-level unit wins
+    expect(exercises['Dip'][0].unit).toBe('lb'); // no unit anywhere -> default
+  });
+
+  it('returns an empty object for a workout with no blocks', () => {
+    expect(buildSessionExercises(undefined)).toEqual({});
+    expect(buildSessionExercises({})).toEqual({});
+  });
+});
+
+describe('buildInitialSessionLog', () => {
+  it('creates Session state with the correct identity and prescribed Set targets', () => {
+    const startedAt = '2026-07-17T10:00:00.000Z';
+    const log = buildInitialSessionLog({
+      logKey: '2026-07-17::Upper A',
+      workout,
+      startedAt,
+    });
+
+    expect(log.logKey).toBe('2026-07-17::Upper A');
+    expect(log.workoutTitle).toBe('Upper A');
+    expect(log.date).toBe('2026-07-17');
+    expect(log.completedAt).toBeNull();
+    expect(log.startedAt).toBe(startedAt);
+    expect(log.exerciseNotes).toEqual({});
+    expect(log.workoutNote).toBe('');
+    expect(log.exercises['Back Squat']).toHaveLength(2);
+    expect(log.exercises['Back Squat'][0].targetWeight).toBe(135);
+  });
+
+  it('defaults startedAt to now when not provided', () => {
+    const before = Date.now();
+    const log = buildInitialSessionLog({ logKey: '2026-07-17::Upper A', workout });
+    const after = Date.now();
+    const ts = new Date(log.startedAt).getTime();
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it('preserves workout titles that contain the :: separator', () => {
+    const log = buildInitialSessionLog({ logKey: '2026-07-17::Leg::Day', workout });
+    expect(log.workoutTitle).toBe('Leg::Day');
+  });
+});
+
+describe('hasLoggedData', () => {
+  it('is false for a freshly initialized log', () => {
+    const log = buildInitialSessionLog({ logKey: '2026-07-17::Upper A', workout });
+    expect(hasLoggedData(log)).toBe(false);
+  });
+
+  it('is true when any set is completed', () => {
+    const log = buildInitialSessionLog({ logKey: '2026-07-17::Upper A', workout });
+    log.exercises['Back Squat'][0].completed = true;
+    expect(hasLoggedData(log)).toBe(true);
+  });
+
+  it('is true when actual reps or weight has been entered', () => {
+    const log = buildInitialSessionLog({ logKey: '2026-07-17::Upper A', workout });
+    log.exercises['Back Squat'][0].actualReps = 5;
+    expect(hasLoggedData(log)).toBe(true);
+
+    const log2 = buildInitialSessionLog({ logKey: '2026-07-17::Upper A', workout });
+    log2.exercises['Back Squat'][0].actualWeight = 135;
+    expect(hasLoggedData(log2)).toBe(true);
+  });
+
+  it('is false for null / malformed logs', () => {
+    expect(hasLoggedData(null)).toBe(false);
+    expect(hasLoggedData({})).toBe(false);
+    expect(hasLoggedData({ exercises: null })).toBe(false);
+  });
+});
+
+describe('isValidWorkout', () => {
+  it('accepts a workout with at least one block that has exercises', () => {
+    expect(isValidWorkout(workout)).toBe(true);
+  });
+
+  it('rejects missing / empty / exercise-less workouts', () => {
+    expect(isValidWorkout(undefined)).toBe(false);
+    expect(isValidWorkout({ blocks: [] })).toBe(false);
+    expect(isValidWorkout({ blocks: [{ exercises: [] }] })).toBe(false);
+    expect(isValidWorkout({ blocks: 'nope' })).toBe(false);
+  });
+});
+
+describe('evaluateSessionRecovery', () => {
+  const now = new Date('2026-07-17T12:00:00.000Z').getTime();
+
+  it('resumes a valid unfinished Session', () => {
+    const result = evaluateSessionRecovery({
+      session: { logKey: '2026-07-17::Upper A', startedAt: '2026-07-17T10:00:00.000Z' },
+      workout,
+      existingLog: { completedAt: null, exercises: {} },
+      now,
+    });
+    expect(result.action).toBe('resume');
+    expect(result.workoutTitle).toBe('Upper A');
+  });
+
+  it('discards a Session older than the max age without prompting', () => {
+    const result = evaluateSessionRecovery({
+      session: { logKey: '2026-07-01::Upper A' },
+      workout,
+      existingLog: null,
+      now,
+    });
+    expect(result.action).toBe('discard');
+    expect(result.reason).toBe('stale');
+  });
+
+  it('keeps a Session that is exactly at the age boundary', () => {
+    const boundaryDate = '2026-07-10';
+    // Evaluate exactly 7 days (to the millisecond) after local midnight of the
+    // Session date, so diffDays === 7 and the Session is not yet stale.
+    const boundaryNow = new Date(`${boundaryDate}T00:00:00`).getTime() + 7 * 24 * 60 * 60 * 1000;
+    const result = evaluateSessionRecovery({
+      session: { logKey: `${boundaryDate}::Upper A` },
+      workout,
+      existingLog: null,
+      now: boundaryNow,
+    });
+    expect(result.action).toBe('resume');
+  });
+
+  it('discards once past the age boundary by any amount', () => {
+    const boundaryDate = '2026-07-10';
+    const justPast = new Date(`${boundaryDate}T00:00:00`).getTime() + 7 * 24 * 60 * 60 * 1000 + 1;
+    const result = evaluateSessionRecovery({
+      session: { logKey: `${boundaryDate}::Upper A` },
+      workout,
+      existingLog: null,
+      now: justPast,
+    });
+    expect(result.action).toBe('discard');
+    expect(result.reason).toBe('stale');
+  });
+
+  it('discards a Session whose Log is already completed', () => {
+    const result = evaluateSessionRecovery({
+      session: { logKey: '2026-07-17::Upper A' },
+      workout,
+      existingLog: { completedAt: '2026-07-17T11:00:00.000Z' },
+      now,
+    });
+    expect(result.action).toBe('discard');
+    expect(result.reason).toBe('completed');
+  });
+
+  it('discards a Session whose Workout is missing or malformed', () => {
+    const result = evaluateSessionRecovery({
+      session: { logKey: '2026-07-17::Deleted' },
+      workout: undefined,
+      existingLog: null,
+      now,
+    });
+    expect(result.action).toBe('discard');
+    expect(result.reason).toBe('invalid-workout');
+  });
+
+  it('discards a Session with an unparseable / non-string logKey', () => {
+    const result = evaluateSessionRecovery({
+      session: { logKey: 12345 },
+      workout,
+      existingLog: null,
+      now,
+    });
+    expect(result.action).toBe('discard');
+  });
+
+  it('discards when there is no session', () => {
+    expect(evaluateSessionRecovery({ session: null, workout, existingLog: null, now }).action).toBe('discard');
+  });
+
+  it('discards a Session with a garbage date component', () => {
+    const result = evaluateSessionRecovery({
+      session: { logKey: 'not-a-date::Upper A' },
+      workout,
+      existingLog: null,
+      now,
+    });
+    expect(result.action).toBe('discard');
+    expect(result.reason).toBe('stale');
+  });
+
+  it('exposes the default max age constant', () => {
+    expect(SESSION_MAX_AGE_DAYS).toBe(7);
+  });
+});

--- a/src/views/ActiveWorkoutView.jsx
+++ b/src/views/ActiveWorkoutView.jsx
@@ -15,6 +15,7 @@ import { buildSummary, findPRs } from '../utils/workoutSummary';
 import { resolveRestDuration } from '../utils/resolveRestDuration';
 import { resolveManualTimerDuration } from '../utils/resolveManualTimerDuration';
 import { shouldStartRestTimer } from '../utils/shouldStartRestTimer';
+import { buildInitialSessionLog, buildSessionExercises, hasLoggedData } from '../session/session';
 
 function findNextActiveWorkoutSet(workout, currentLog) {
   if (!workout?.blocks || !currentLog?.exercises) return null;
@@ -64,18 +65,7 @@ export default function ActiveWorkoutView({
 
   const [currentLog, setCurrentLog] = useState(() => {
     if (log) return log;
-
-    // Create new log skeleton
-    return {
-      logKey,
-      workoutTitle,
-      date,
-      completedAt: null,
-      startedAt: new Date().toISOString(),
-      exercises: {},
-      exerciseNotes: {},
-      workoutNote: '',
-    };
+    return buildInitialSessionLog({ logKey, workout });
   });
 
   const [showCancelModal, setShowCancelModal] = useState(false);
@@ -201,32 +191,16 @@ export default function ActiveWorkoutView({
   // Initialize exercise logs
   useEffect(() => {
     if (!workout) return;
-    // Skip if exercises already have actual logged data (crash recovery)
-    if (currentLog.exercises && Object.keys(currentLog.exercises).length > 0) {
-      const hasLoggedData = Object.values(currentLog.exercises).some((sets) =>
-        Array.isArray(sets) && sets.some((s) =>
-          s.completed || (s.actualReps !== undefined && s.actualReps !== '') || (s.actualWeight !== undefined && s.actualWeight !== '')
-        )
-      );
-      if (hasLoggedData) return;
+    // Skip re-initialization if the Log already holds recovered performance data.
+    if (
+      currentLog.exercises &&
+      Object.keys(currentLog.exercises).length > 0 &&
+      hasLoggedData(currentLog)
+    ) {
+      return;
     }
 
-    const newExercises = {};
-    workout.blocks.forEach((block) => {
-      block.exercises.forEach((exercise) => {
-        newExercises[exercise.title] = exercise.sets.map((_, setIdx) => ({
-          setIndex: setIdx,
-          targetReps: exercise.sets[setIdx].reps,
-          targetWeight: exercise.sets[setIdx].weight,
-          unit: exercise.sets[setIdx].unit || exercise.unit || 'lb',
-          actualReps: '',
-          actualWeight: '',
-          completed: false,
-        }));
-      });
-    });
-
-    const updated = { ...currentLog, exercises: newExercises };
+    const updated = { ...currentLog, exercises: buildSessionExercises(workout) };
     setCurrentLog(updated);
     saveLog(logKey, updated);
   }, []);


### PR DESCRIPTION
## Summary

Establishes a testable **Session logging module** (`src/session/session.js`) that owns the deterministic parts of **starting** and **resuming** an active Session, extracting this logic out of `ActiveWorkoutView.jsx` and `App.jsx`. Behavior is preserved — this is a behavior-neutral refactor that makes crash-recovery and Session initialization provable at the module seam (per parent PRD #50).

Closes #63

## What changed

- **New `src/session/session.js`** (pure functions):
  - `buildSessionExercises(workout)` — prescribed Set targets map (reps/weight/unit, uncompleted).
  - `buildInitialSessionLog({ logKey, workout, startedAt })` — full initial Session Log with correct identity (logKey/workoutTitle/date), open completion state, start time, and prescribed Sets.
  - `hasLoggedData(log)` — recovery guard so recovered performance is never overwritten by re-initialization.
  - `isValidWorkout(workout)` — Part/Exercise validity.
  - `evaluateSessionRecovery({ session, workout, existingLog, now, maxAgeDays })` — resume vs discard decision (stale > 7 days, unparseable logKey, already-completed Log, invalid/deleted Workout).
- **`ActiveWorkoutView.jsx`** now builds the initial Session Log and re-initializes prescribed targets via the module helpers instead of inline logic.
- **`App.jsx`** crash-recovery effect now delegates the resume/discard decision to `evaluateSessionRecovery`; accept/decline handlers (navigate / `clearSession`) are unchanged.

## Acceptance criteria

- [x] Starting creates Session state with correct identity and prescribed Set targets.
- [x] A valid unfinished Session restores completed Sets, Session notes, and original start time through the existing resume flow.
- [x] Stale, malformed, completed, or invalid-Workout Sessions are discarded without a prompt.
- [x] Accepting or declining resume preserves current History and recovery-state effects.
- [x] Unit coverage and desktop/mobile Workout journeys pass without user-visible change.

## Tests

- `src/session/session.test.js` — 22 unit tests covering start initialization, unit-precedence, recovery guard, workout validity, and all discard/resume branches (including exact age boundary).
- `e2e/session-resume.e2e.js` — new journeys: resume restores completed Sets after a mid-Session reload; discard clears the Session and returns to Training.
- Full gate green: `npm run test:unit` (594), `npm run test:e2e` (92 passed / 6 skipped), `npm run build`.

## Visual evidence (desktop + mobile, inspected)

- `artifacts/visual/chromium/session-resume-prompt.png`
- `artifacts/visual/mobile-chrome/session-resume-prompt.png`

Both show the unchanged Resume prompt (workout name, date, "1 of 7 sets completed", Discard/Resume) rendering cleanly with correct dark-theme styling, no clipping/overflow, and correct dialog layering.

## Decisions

- Placed the module at `src/session/session.js` (new `session/` directory) to seed the deep Session module described in PRD #50, rather than adding another file under `src/utils/`.
- `evaluateSessionRecovery` returns a `{ action, reason }` object so future slices can branch on discard reasons; the current caller only distinguishes resume vs discard, matching prior behavior.
- Kept the stale-age formula identical to the previous inline logic (local-midnight of the Session date vs `now`), so the 7-day cutoff behaves exactly as before.

## Review notes

Dual-model review complete — both reviewers returned **zero findings**:
- **gpt-5.5** (code quality & correctness): "No significant issues found."
- **claude-opus-4.8** (security): "No significant security issues found." Confirmed no new prototype-pollution surface (identical to prior inline code), NaN-safe date parsing, no unsafe DOM/eval sinks, and no personal-data exposure.

