### PR TITLE
feat: persist Exercise and Session Workout notes through the Session module

### DIFF
--- a/e2e/session-resume.e2e.js
+++ b/e2e/session-resume.e2e.js
@@ -7,7 +7,6 @@ import {
   importSampleCsv,
   quickStartLowerBodyWorkout,
 } from './helpers';
-
 // Simulates a crash: an active Session is left in localStorage mid-Workout,
 // then the PWA is reloaded. The Session module drives the resume decision.
 
@@ -66,4 +65,36 @@ test('discarding an unfinished Session clears it and returns to Training', async
 
   await page.reload();
   await expect(page.getByRole('heading', { name: 'Resume Workout?' })).toHaveCount(0);
+});
+
+test('@visual Exercise and Session Workout notes survive crash recovery and resume', async ({ page }, testInfo) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+  await quickStartLowerBodyWorkout(page);
+
+  // Log a Set so recovery treats this as a resumable Session.
+  await completeNextSet(page);
+
+  // Add an Exercise-scoped Session note on the first Exercise.
+  await page.getByRole('button', { name: 'Add a note…' }).first().click();
+  const exerciseNoteInput = page.getByPlaceholder('Note (e.g. felt weak, RPE 8, elbow pain)');
+  await exerciseNoteInput.fill('elbow twinge, RPE 8');
+  await exerciseNoteInput.blur();
+
+  // Add the overall Session Workout note.
+  const sessionNoteInput = page.getByPlaceholder(/How did the session feel/);
+  await sessionNoteInput.fill('low energy today');
+  await sessionNoteInput.blur();
+
+  // "Crash" mid-Session, then resume.
+  await page.reload();
+  await expect(page.getByRole('heading', { name: 'Resume Workout?' })).toBeVisible();
+  await page.getByRole('button', { name: 'Resume' }).click();
+  await expect(page.getByRole('button', { name: 'Finish (1/7 sets)' })).toBeVisible();
+
+  // Both note types are recovered, each on its own field.
+  await expect(page.getByRole('button', { name: /elbow twinge, RPE 8/ })).toBeVisible();
+  await expect(page.getByPlaceholder(/How did the session feel/)).toHaveValue('low energy today');
+
+  await captureVisualEvidence(page, testInfo, 'session-notes-recovered', { fullPage: true });
 });

--- a/src/session/session.js
+++ b/src/session/session.js
@@ -15,6 +15,57 @@ import { parseLogKey } from '../constants';
 export const SESSION_MAX_AGE_DAYS = 7;
 
 /**
+ * Named Session intentions. Editing interactions describe *what* changed as one
+ * of these intentions and hand it to {@link applySessionIntent}, which returns a
+ * new Session Log. Views never mutate persisted note state directly.
+ */
+export const SESSION_INTENT = {
+  SET_EXERCISE_NOTE: 'session/set-exercise-note',
+  SET_WORKOUT_NOTE: 'session/set-workout-note',
+};
+
+/**
+ * Intention: set the Session note scoped to a single Exercise. This is distinct
+ * from the Exercise's form notes (`exercise.notes`) and its workout-specific
+ * notes (`exercise.workoutNotes`), which live on the Workout definition, not the
+ * Session Log.
+ */
+export function setExerciseNoteIntent(exerciseTitle, note) {
+  return { type: SESSION_INTENT.SET_EXERCISE_NOTE, exerciseTitle, note };
+}
+
+/** Intention: set the overall Session Workout note on the current Session. */
+export function setWorkoutNoteIntent(note) {
+  return { type: SESSION_INTENT.SET_WORKOUT_NOTE, note };
+}
+
+/**
+ * Apply a Session intention to a Session Log, returning a new Log. Pure and
+ * immutable: the input Log is never mutated, so recovered/persisted state stays
+ * intact. Unknown intentions and null Logs are returned unchanged.
+ */
+export function applySessionIntent(log, intent) {
+  if (!log || !intent) return log;
+
+  switch (intent.type) {
+    case SESSION_INTENT.SET_EXERCISE_NOTE: {
+      if (!intent.exerciseTitle) return log;
+      return {
+        ...log,
+        exerciseNotes: {
+          ...(log.exerciseNotes || {}),
+          [intent.exerciseTitle]: intent.note,
+        },
+      };
+    }
+    case SESSION_INTENT.SET_WORKOUT_NOTE:
+      return { ...log, workoutNote: intent.note };
+    default:
+      return log;
+  }
+}
+
+/**
  * Build the prescribed Set targets map for a Workout: exerciseTitle -> Set[].
  * Each entry mirrors the prescribed reps/weight/unit and starts uncompleted.
  */

--- a/src/session/session.test.js
+++ b/src/session/session.test.js
@@ -1,11 +1,15 @@
 import { describe, it, expect } from 'vitest';
 import {
   SESSION_MAX_AGE_DAYS,
+  SESSION_INTENT,
   buildSessionExercises,
   buildInitialSessionLog,
   hasLoggedData,
   isValidWorkout,
   evaluateSessionRecovery,
+  setExerciseNoteIntent,
+  setWorkoutNoteIntent,
+  applySessionIntent,
 } from './session.js';
 
 const workout = {
@@ -238,5 +242,112 @@ describe('evaluateSessionRecovery', () => {
 
   it('exposes the default max age constant', () => {
     expect(SESSION_MAX_AGE_DAYS).toBe(7);
+  });
+});
+
+describe('Session note intentions', () => {
+  const baseLog = () => buildInitialSessionLog({ logKey: '2026-07-17::Upper A', workout });
+
+  describe('setExerciseNoteIntent + applySessionIntent', () => {
+    it('scopes an Exercise Session note to that Exercise only', () => {
+      const log = baseLog();
+      const next = applySessionIntent(log, setExerciseNoteIntent('Back Squat', 'RPE 8, felt strong'));
+
+      expect(next.exerciseNotes['Back Squat']).toBe('RPE 8, felt strong');
+      expect(next.exerciseNotes['Pull-Up']).toBeUndefined();
+    });
+
+    it('does not mutate the original Log (immutable intention)', () => {
+      const log = baseLog();
+      const next = applySessionIntent(log, setExerciseNoteIntent('Back Squat', 'hi'));
+
+      expect(log.exerciseNotes['Back Squat']).toBeUndefined();
+      expect(next).not.toBe(log);
+      expect(next.exerciseNotes).not.toBe(log.exerciseNotes);
+    });
+
+    it('leaves prescribed Sets and the Session Workout note untouched', () => {
+      const log = baseLog();
+      log.workoutNote = 'overall note';
+      const next = applySessionIntent(log, setExerciseNoteIntent('Back Squat', 'note'));
+
+      expect(next.workoutNote).toBe('overall note');
+      expect(next.exercises).toEqual(log.exercises);
+    });
+
+    it('updates an existing Exercise note without disturbing sibling notes', () => {
+      const log = baseLog();
+      const withTwo = applySessionIntent(
+        applySessionIntent(log, setExerciseNoteIntent('Back Squat', 'first')),
+        setExerciseNoteIntent('Pull-Up', 'second')
+      );
+      const updated = applySessionIntent(withTwo, setExerciseNoteIntent('Back Squat', 'edited'));
+
+      expect(updated.exerciseNotes['Back Squat']).toBe('edited');
+      expect(updated.exerciseNotes['Pull-Up']).toBe('second');
+    });
+
+    it('ignores an intention with no Exercise title', () => {
+      const log = baseLog();
+      const next = applySessionIntent(log, setExerciseNoteIntent('', 'orphan'));
+      expect(next).toBe(log);
+    });
+  });
+
+  describe('setWorkoutNoteIntent + applySessionIntent', () => {
+    it('persists the Session Workout note on the current Session', () => {
+      const log = baseLog();
+      const next = applySessionIntent(log, setWorkoutNoteIntent('great pump'));
+      expect(next.workoutNote).toBe('great pump');
+    });
+
+    it('does not mutate the original Log', () => {
+      const log = baseLog();
+      const next = applySessionIntent(log, setWorkoutNoteIntent('tired today'));
+      expect(log.workoutNote).toBe('');
+      expect(next).not.toBe(log);
+    });
+
+    it('leaves Exercise Session notes untouched', () => {
+      const log = applySessionIntent(baseLog(), setExerciseNoteIntent('Back Squat', 'ex note'));
+      const next = applySessionIntent(log, setWorkoutNoteIntent('session note'));
+      expect(next.exerciseNotes['Back Squat']).toBe('ex note');
+      expect(next.workoutNote).toBe('session note');
+    });
+  });
+
+  describe('applySessionIntent guards', () => {
+    it('exposes the Session intent type constants', () => {
+      expect(SESSION_INTENT.SET_EXERCISE_NOTE).toBeTruthy();
+      expect(SESSION_INTENT.SET_WORKOUT_NOTE).toBeTruthy();
+    });
+
+    it('returns the Log unchanged for a null log or unknown intent', () => {
+      const log = baseLog();
+      expect(applySessionIntent(null, setWorkoutNoteIntent('x'))).toBeNull();
+      expect(applySessionIntent(log, null)).toBe(log);
+      expect(applySessionIntent(log, { type: 'nope' })).toBe(log);
+    });
+
+    it('survives crash recovery: notes on a persisted Log round-trip through recovery', () => {
+      // A persisted (crashed) Session Log carrying both note types.
+      let recovered = buildInitialSessionLog({ logKey: '2026-07-17::Upper A', workout });
+      recovered = applySessionIntent(recovered, setExerciseNoteIntent('Back Squat', 'elbow twinge'));
+      recovered = applySessionIntent(recovered, setWorkoutNoteIntent('low energy'));
+
+      // Simulate reload: JSON round-trip through localStorage.
+      const reloaded = JSON.parse(JSON.stringify(recovered));
+
+      const decision = evaluateSessionRecovery({
+        session: { logKey: reloaded.logKey, startedAt: reloaded.startedAt },
+        workout,
+        existingLog: reloaded,
+        now: new Date('2026-07-17T12:00:00.000Z').getTime(),
+      });
+
+      expect(decision.action).toBe('resume');
+      expect(reloaded.exerciseNotes['Back Squat']).toBe('elbow twinge');
+      expect(reloaded.workoutNote).toBe('low energy');
+    });
   });
 });

--- a/src/views/ActiveWorkoutView.jsx
+++ b/src/views/ActiveWorkoutView.jsx
@@ -15,7 +15,7 @@ import { buildSummary, findPRs } from '../utils/workoutSummary';
 import { resolveRestDuration } from '../utils/resolveRestDuration';
 import { resolveManualTimerDuration } from '../utils/resolveManualTimerDuration';
 import { shouldStartRestTimer } from '../utils/shouldStartRestTimer';
-import { buildInitialSessionLog, buildSessionExercises, hasLoggedData } from '../session/session';
+import { buildInitialSessionLog, buildSessionExercises, hasLoggedData, applySessionIntent, setExerciseNoteIntent, setWorkoutNoteIntent } from '../session/session';
 
 function findNextActiveWorkoutSet(workout, currentLog) {
   if (!workout?.blocks || !currentLog?.exercises) return null;
@@ -255,19 +255,13 @@ export default function ActiveWorkoutView({
   };
 
   const updateExerciseNote = (exerciseTitle, note) => {
-    const updated = {
-      ...currentLog,
-      exerciseNotes: {
-        ...(currentLog.exerciseNotes || {}),
-        [exerciseTitle]: note,
-      },
-    };
+    const updated = applySessionIntent(currentLog, setExerciseNoteIntent(exerciseTitle, note));
     setCurrentLog(updated);
     saveLog(logKey, updated);
   };
 
   const updateWorkoutNote = useCallback((note) => {
-    const updated = { ...currentLog, workoutNote: note };
+    const updated = applySessionIntent(currentLog, setWorkoutNoteIntent(note));
     setCurrentLog(updated);
     saveLog(logKey, updated);
   }, [currentLog, logKey, saveLog]);


### PR DESCRIPTION
## Summary

Persists Exercise Session notes and the Session Workout note through the Session module, driven by pure, immutable **Session intentions** rather than direct mutation of persisted note state in `ActiveWorkoutView`.

Closes #65

## What changed

- **`src/session/session.js`** — new pure API:
  - `SESSION_INTENT` — intent type constants.
  - `setExerciseNoteIntent(exerciseTitle, note)` / `setWorkoutNoteIntent(note)` — intent creators.
  - `applySessionIntent(log, intent)` — pure reducer returning a new Session Log; never mutates the input, ignores null Logs / unknown intents / note intents with no Exercise title.
- **`src/views/ActiveWorkoutView.jsx`** — `updateExerciseNote` and `updateWorkoutNote` now dispatch through `applySessionIntent` instead of hand-building the mutated Log object. No UI/DOM change.
- **Tests** — unit coverage for both note types (scoping, immutability, sibling-note isolation, guards, and a JSON round-trip recovery case), plus a new e2e that adds both note types, "crashes" via reload, resumes, and asserts both notes recover.

## Acceptance criteria

- [x] An Exercise Session note remains scoped to that Exercise and does not change form (`exercise.notes`) or workout-specific (`exercise.workoutNotes`) notes — those live on the Workout definition, not the Session Log, so they are structurally untouched.
- [x] A Session Workout note persists on the current Session (`log.workoutNote`).
- [x] Both note types survive crash recovery and resume (unit round-trip + e2e reload/resume).
- [x] Editing interactions dispatch Session intentions instead of directly mutating persisted note state.
- [x] Tests cover both note types and recovery.

## Decisions

- Modeled the intention layer as a small dispatcher (`applySessionIntent`) plus intent-creator helpers, mirroring the existing pure-function style of the Session module from #63. This keeps the state machine testable without rendering the view.
- "Does not change form / workout-specific notes" is satisfied structurally: those fields live on the Workout/Template definition, not on the Session Log, and the intentions only ever touch `log.exerciseNotes[title]` / `log.workoutNote`. Added explicit tests asserting the prescribed Sets and the sibling note field are left untouched.

## Validation

- `npm run test:unit` — 605 passed (session module: 33).
- `npm run test:e2e` — 94 passed / 6 skipped.
- `npm run build` — succeeds.
- `npm run test:e2e:visual` + `npm run test:ci` — green.

## Visual evidence (inspected)

- `artifacts/visual/chromium/session-notes-recovered.png`
- `artifacts/visual/mobile-chrome/session-notes-recovered.png`

Both show the Exercise Session note ("elbow twinge, RPE 8") recovered and scoped to the Leg Swings Exercise after a mid-Session reload/resume, with the completed 1/7 Set intact and consistent dark-theme styling (no clipping/overlap). The Session Workout note recovery is asserted via `toHaveValue('low energy today')`.

## Review notes

Dual-model code review (mandatory pre-merge):

- **gpt-5.5 — code quality & correctness:** No significant issues found. Verified the refactor is behavior-preserving, the intention functions are correctly immutable, and both note types recover without edge-case regressions.
- **claude-opus-4.8 — security:** No significant issues found. Specifically confirmed the computed-key assignment in `applySessionIntent` is **not** prototype-pollutable (a computed object-literal key defines an own enumerable property; it does not touch `Object.prototype`), and that note strings cannot cause stored XSS — every render site uses React's auto-escaping JSX text interpolation with no `dangerouslySetInnerHTML` sinks.

Both models returned zero adoptable findings; no fix commits were required.
