### PR TITLE
feat: confirm active-Session target edits through the Session module

### DIFF
--- a/e2e/template-session-target-consistency.e2e.js
+++ b/e2e/template-session-target-consistency.e2e.js
@@ -62,3 +62,33 @@ test('@visual Session target confirmation propagates back to the Template', asyn
   await expect(templateFirstSetReps).toHaveValue('5');
   await captureVisualEvidence(page, testInfo, 'template-target-reflects-session-confirmation');
 });
+
+test('@visual Discarding Session target edits leaves the Workout and Template unchanged', async ({ page }, testInfo) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+
+  // Start the Workout, enter edit mode, change the first set target, then discard.
+  await startLowerBodyB(page);
+  await expect(page.locator('.log-set-row__target').first()).toHaveText('3 × BW');
+
+  await page.getByRole('button', { name: 'Edit workout' }).click();
+  const firstEditReps = page.locator('.log-set-row__input').first();
+  await firstEditReps.fill('7');
+  await expect(firstEditReps).toHaveValue('7');
+  await captureVisualEvidence(page, testInfo, 'session-target-edit-pending-before-discard');
+
+  await page.getByRole('button', { name: 'Discard' }).click();
+
+  // Back in logging mode, the target reverts to its prescribed value — the
+  // pending edit never reached the Workout.
+  await expect(page.locator('.log-set-row__target').first()).toHaveText('3 × BW');
+  await captureVisualEvidence(page, testInfo, 'session-target-unchanged-after-discard');
+
+  // Leave the session and confirm the matching Template is untouched.
+  await page.getByRole('button', { name: 'Cancel workout' }).click();
+  await page.getByRole('button', { name: 'Cancel Workout', exact: true }).click();
+  await expect(page.getByRole('heading', { name: /Good (morning|afternoon|evening)/ })).toBeVisible();
+
+  await openLowerBodyBTemplate(page);
+  await expect(page.locator('.tpl-editor__set-input').first()).toHaveValue('3');
+});

--- a/src/session/session.js
+++ b/src/session/session.js
@@ -215,6 +215,11 @@ function draftSets(draft, blockIndex, exerciseIndex) {
   return Array.isArray(exercise?.sets) ? exercise.sets : null;
 }
 
+// A valid, in-range Set position: a non-negative integer within the array.
+function isSetPosition(setIndex, sets) {
+  return Number.isInteger(setIndex) && setIndex >= 0 && setIndex < sets.length;
+}
+
 /**
  * Edit a prescribed target (reps or weight) on a draft Set, returning a new
  * draft. Non-editable fields and out-of-range coordinates are ignored (the
@@ -224,7 +229,7 @@ export function editTargetSet(draft, { blockIndex, exerciseIndex, setIndex, fiel
   if (!draft) return draft;
   if (!EDITABLE_TARGET_FIELDS.has(field)) return draft;
   const sets = draftSets(draft, blockIndex, exerciseIndex);
-  if (!sets || setIndex < 0 || setIndex >= sets.length) return draft;
+  if (!sets || !isSetPosition(setIndex, sets)) return draft;
 
   const next = cloneBlocks(draft);
   next[blockIndex].exercises[exerciseIndex].sets[setIndex][field] = value;
@@ -255,7 +260,7 @@ export function addTargetSet(draft, { blockIndex, exerciseIndex }) {
 export function removeTargetSet(draft, { blockIndex, exerciseIndex, setIndex }) {
   if (!draft) return draft;
   const sets = draftSets(draft, blockIndex, exerciseIndex);
-  if (!sets || setIndex < 0 || setIndex >= sets.length) return draft;
+  if (!sets || !isSetPosition(setIndex, sets)) return draft;
   if (sets.length <= 1) return draft;
 
   const next = cloneBlocks(draft);

--- a/src/session/session.js
+++ b/src/session/session.js
@@ -185,3 +185,99 @@ export function evaluateSessionRecovery({
 
   return { action: 'resume', workoutTitle, date };
 }
+
+// ─── Target-edit mode ───────────────────────────────────
+
+// Editable target fields on a prescribed Set. Editing is limited to the
+// prescription (reps/weight); the Exercise identity and unit stay fixed.
+const EDITABLE_TARGET_FIELDS = new Set(['reps', 'weight']);
+
+// Reference-free copy so a pending draft shares no nested Parts/Exercises/Sets
+// with the source Workout — pending edits stay Session state until confirmed.
+function cloneBlocks(blocks) {
+  if (typeof structuredClone === 'function') return structuredClone(blocks);
+  return JSON.parse(JSON.stringify(blocks));
+}
+
+/**
+ * Open a target-edit draft for a Workout. Returns a deep clone of the Workout's
+ * Parts so edits accumulate in Session state without mutating the persisted
+ * Workout. Returns null for an invalid Workout, so no edit mode opens.
+ */
+export function beginTargetEdit(workout) {
+  if (!isValidWorkout(workout)) return null;
+  return cloneBlocks(workout.blocks);
+}
+
+// Locate the Set array for a draft coordinate, or null when out of range.
+function draftSets(draft, blockIndex, exerciseIndex) {
+  const exercise = draft?.[blockIndex]?.exercises?.[exerciseIndex];
+  return Array.isArray(exercise?.sets) ? exercise.sets : null;
+}
+
+/**
+ * Edit a prescribed target (reps or weight) on a draft Set, returning a new
+ * draft. Non-editable fields and out-of-range coordinates are ignored (the
+ * input draft is returned unchanged).
+ */
+export function editTargetSet(draft, { blockIndex, exerciseIndex, setIndex, field, value }) {
+  if (!draft) return draft;
+  if (!EDITABLE_TARGET_FIELDS.has(field)) return draft;
+  const sets = draftSets(draft, blockIndex, exerciseIndex);
+  if (!sets || setIndex < 0 || setIndex >= sets.length) return draft;
+
+  const next = cloneBlocks(draft);
+  next[blockIndex].exercises[exerciseIndex].sets[setIndex][field] = value;
+  return next;
+}
+
+/**
+ * Append a Set to a draft Exercise, copying the last prescribed Set's targets.
+ * Out-of-range coordinates return the input draft unchanged.
+ */
+export function addTargetSet(draft, { blockIndex, exerciseIndex }) {
+  if (!draft) return draft;
+  const sets = draftSets(draft, blockIndex, exerciseIndex);
+  if (!sets) return draft;
+
+  const next = cloneBlocks(draft);
+  const nextSets = next[blockIndex].exercises[exerciseIndex].sets;
+  const base = nextSets[nextSets.length - 1] || { reps: null, weight: null, unit: 'lb' };
+  nextSets.push({ ...base });
+  return next;
+}
+
+/**
+ * Remove a Set from a draft Exercise, returning a new draft. Refuses to remove
+ * an Exercise's final Set (returns the input draft unchanged), so every
+ * Exercise always keeps at least one prescribed Set.
+ */
+export function removeTargetSet(draft, { blockIndex, exerciseIndex, setIndex }) {
+  if (!draft) return draft;
+  const sets = draftSets(draft, blockIndex, exerciseIndex);
+  if (!sets || setIndex < 0 || setIndex >= sets.length) return draft;
+  if (sets.length <= 1) return draft;
+
+  const next = cloneBlocks(draft);
+  next[blockIndex].exercises[exerciseIndex].sets.splice(setIndex, 1);
+  return next;
+}
+
+/**
+ * Confirm a target-edit draft. Returns a Training Plan lifecycle change
+ * (`syncBlocks`) that, applied via the lifecycle authority (`applyTemplateChange`),
+ * updates the matching Workout and Template. Returns null when there is no
+ * draft to confirm.
+ */
+export function confirmTargetEdit(draft, workoutTitle) {
+  if (!draft) return null;
+  return { type: 'syncBlocks', workoutTitle, blocks: draft };
+}
+
+/**
+ * Discard a target-edit draft. Produces no lifecycle change, so neither the
+ * Workout nor the Template is touched.
+ */
+export function discardTargetEdit() {
+  return null;
+}

--- a/src/session/session.test.js
+++ b/src/session/session.test.js
@@ -444,6 +444,13 @@ describe('target-edit mode', () => {
       ).toBe(draft);
       expect(editTargetSet(null, { blockIndex: 0, exerciseIndex: 0, setIndex: 0, field: 'reps', value: 1 })).toBeNull();
     });
+
+    it('ignores non-integer Set coordinates instead of throwing', () => {
+      const draft = beginTargetEdit(targetWorkout());
+      for (const setIndex of [undefined, null, NaN, 1.5, '0']) {
+        expect(editTargetSet(draft, { blockIndex: 0, exerciseIndex: 0, setIndex, field: 'reps', value: 1 })).toBe(draft);
+      }
+    });
   });
 
   describe('addTargetSet', () => {
@@ -481,6 +488,15 @@ describe('target-edit mode', () => {
       const next = removeTargetSet(draft, { blockIndex: 1, exerciseIndex: 0, setIndex: 0 });
       expect(next).toBe(draft);
       expect(next[1].exercises[0].sets).toHaveLength(1);
+    });
+
+    it('ignores non-integer Set coordinates instead of removing the first Set', () => {
+      const draft = beginTargetEdit(targetWorkout());
+      for (const setIndex of [undefined, null, NaN, 1.5, '0']) {
+        const next = removeTargetSet(draft, { blockIndex: 0, exerciseIndex: 0, setIndex });
+        expect(next).toBe(draft);
+        expect(next[0].exercises[0].sets).toHaveLength(2);
+      }
     });
   });
 

--- a/src/session/session.test.js
+++ b/src/session/session.test.js
@@ -10,7 +10,14 @@ import {
   setExerciseNoteIntent,
   setWorkoutNoteIntent,
   applySessionIntent,
+  beginTargetEdit,
+  editTargetSet,
+  addTargetSet,
+  removeTargetSet,
+  confirmTargetEdit,
+  discardTargetEdit,
 } from './session.js';
+import { applyTemplateChange } from '../orchestrator.js';
 
 const workout = {
   blocks: [
@@ -348,6 +355,177 @@ describe('Session note intentions', () => {
       expect(decision.action).toBe('resume');
       expect(reloaded.exerciseNotes['Back Squat']).toBe('elbow twinge');
       expect(reloaded.workoutNote).toBe('low energy');
+    });
+  });
+});
+
+describe('target-edit mode', () => {
+  // A Workout whose prescribed Set targets (reps/weight) the athlete may edit
+  // mid-Session before confirming back to the Training Plan.
+  const targetWorkout = () => ({
+    blocks: [
+      {
+        exercises: [
+          {
+            title: 'Back Squat',
+            unit: 'lb',
+            sets: [
+              { reps: 5, weight: 135 },
+              { reps: 5, weight: 155 },
+            ],
+          },
+        ],
+      },
+      {
+        exercises: [
+          { title: 'Pull-Up', sets: [{ reps: 8, weight: 'BW', unit: 'reps' }] },
+          { title: 'Dip', sets: [{ reps: 10, weight: 0 }] },
+        ],
+      },
+    ],
+  });
+
+  describe('beginTargetEdit', () => {
+    it('opens a pending draft that deep-clones the Workout Parts and Sets', () => {
+      const workout = targetWorkout();
+      const draft = beginTargetEdit(workout);
+
+      expect(draft).toEqual(workout.blocks);
+      // Draft is a reference-free copy: mutating it never touches the Workout.
+      draft[0].exercises[0].sets[0].reps = 999;
+      expect(workout.blocks[0].exercises[0].sets[0].reps).toBe(5);
+    });
+
+    it('returns null for an invalid Workout so no edit mode opens', () => {
+      expect(beginTargetEdit(null)).toBeNull();
+      expect(beginTargetEdit({ blocks: [] })).toBeNull();
+      expect(beginTargetEdit({ blocks: [{ exercises: [] }] })).toBeNull();
+    });
+  });
+
+  describe('editTargetSet', () => {
+    it('edits reps on a Set immutably, leaving the prior draft untouched', () => {
+      const draft = beginTargetEdit(targetWorkout());
+      const next = editTargetSet(draft, {
+        blockIndex: 0,
+        exerciseIndex: 0,
+        setIndex: 1,
+        field: 'reps',
+        value: 3,
+      });
+
+      expect(next[0].exercises[0].sets[1].reps).toBe(3);
+      expect(draft[0].exercises[0].sets[1].reps).toBe(5);
+      expect(next).not.toBe(draft);
+    });
+
+    it('edits weight on a Set', () => {
+      const draft = beginTargetEdit(targetWorkout());
+      const next = editTargetSet(draft, {
+        blockIndex: 0,
+        exerciseIndex: 0,
+        setIndex: 0,
+        field: 'weight',
+        value: 185,
+      });
+      expect(next[0].exercises[0].sets[0].weight).toBe(185);
+    });
+
+    it('ignores fields other than reps/weight and out-of-range coordinates', () => {
+      const draft = beginTargetEdit(targetWorkout());
+      expect(
+        editTargetSet(draft, { blockIndex: 0, exerciseIndex: 0, setIndex: 0, field: 'title', value: 'x' })
+      ).toBe(draft);
+      expect(
+        editTargetSet(draft, { blockIndex: 9, exerciseIndex: 0, setIndex: 0, field: 'reps', value: 1 })
+      ).toBe(draft);
+      expect(
+        editTargetSet(draft, { blockIndex: 0, exerciseIndex: 0, setIndex: 9, field: 'reps', value: 1 })
+      ).toBe(draft);
+      expect(editTargetSet(null, { blockIndex: 0, exerciseIndex: 0, setIndex: 0, field: 'reps', value: 1 })).toBeNull();
+    });
+  });
+
+  describe('addTargetSet', () => {
+    it('appends a copy of the last prescribed Set immutably', () => {
+      const draft = beginTargetEdit(targetWorkout());
+      const next = addTargetSet(draft, { blockIndex: 0, exerciseIndex: 0 });
+
+      expect(next[0].exercises[0].sets).toHaveLength(3);
+      expect(next[0].exercises[0].sets[2]).toEqual({ reps: 5, weight: 155 });
+      // Appended Set is a copy, not shared with the source Set.
+      expect(next[0].exercises[0].sets[2]).not.toBe(next[0].exercises[0].sets[1]);
+      expect(draft[0].exercises[0].sets).toHaveLength(2);
+    });
+
+    it('returns the draft unchanged for out-of-range coordinates', () => {
+      const draft = beginTargetEdit(targetWorkout());
+      expect(addTargetSet(draft, { blockIndex: 9, exerciseIndex: 0 })).toBe(draft);
+      expect(addTargetSet(null, { blockIndex: 0, exerciseIndex: 0 })).toBeNull();
+    });
+  });
+
+  describe('removeTargetSet', () => {
+    it('removes the targeted Set immutably', () => {
+      const draft = beginTargetEdit(targetWorkout());
+      const next = removeTargetSet(draft, { blockIndex: 0, exerciseIndex: 0, setIndex: 0 });
+
+      expect(next[0].exercises[0].sets).toHaveLength(1);
+      expect(next[0].exercises[0].sets[0]).toEqual({ reps: 5, weight: 155 });
+      expect(draft[0].exercises[0].sets).toHaveLength(2);
+    });
+
+    it("refuses to remove an Exercise's final Set", () => {
+      const draft = beginTargetEdit(targetWorkout());
+      // Pull-Up (block 1, exercise 0) has a single Set — removal must be a no-op.
+      const next = removeTargetSet(draft, { blockIndex: 1, exerciseIndex: 0, setIndex: 0 });
+      expect(next).toBe(draft);
+      expect(next[1].exercises[0].sets).toHaveLength(1);
+    });
+  });
+
+  describe('confirmTargetEdit', () => {
+    it('routes edited targets through the Training Plan lifecycle authority to Workout and Template', () => {
+      const draft = beginTargetEdit(targetWorkout());
+      const edited = editTargetSet(draft, {
+        blockIndex: 0,
+        exerciseIndex: 0,
+        setIndex: 0,
+        field: 'reps',
+        value: 3,
+      });
+
+      const change = confirmTargetEdit(edited, 'Upper A');
+      expect(change).toEqual({ type: 'syncBlocks', workoutTitle: 'Upper A', blocks: edited });
+
+      // Feed the change to the lifecycle authority and prove both sides update.
+      const snapshot = {
+        workouts: { 'Upper A': { title: 'Upper A', blocks: targetWorkout().blocks } },
+        templates: { t1: { id: 't1', name: 'Upper A', blocks: targetWorkout().blocks } },
+        schedule: {},
+        logs: {},
+      };
+      const result = applyTemplateChange(snapshot, change);
+      expect(result.workouts['Upper A'].blocks[0].exercises[0].sets[0].reps).toBe(3);
+      expect(result.templates.t1.blocks[0].exercises[0].sets[0].reps).toBe(3);
+    });
+
+    it('returns null when there is no draft to confirm', () => {
+      expect(confirmTargetEdit(null, 'Upper A')).toBeNull();
+    });
+  });
+
+  describe('discardTargetEdit', () => {
+    it('yields no change so neither Workout nor Template is touched', () => {
+      const draft = beginTargetEdit(targetWorkout());
+      editTargetSet(draft, { blockIndex: 0, exerciseIndex: 0, setIndex: 0, field: 'reps', value: 3 });
+
+      // Discarding produces no lifecycle change...
+      expect(discardTargetEdit()).toBeNull();
+
+      // ...and the source Workout blocks remain exactly as prescribed.
+      const workout = targetWorkout();
+      expect(draft).toEqual(workout.blocks);
     });
   });
 });

--- a/src/styles/active-workout.css
+++ b/src/styles/active-workout.css
@@ -1482,6 +1482,18 @@
   font-weight: 700;
 }
 
+.aw-edit-banner__discard {
+  margin-left: auto;
+  padding: var(--space-xs) var(--space-sm);
+  border: 1px solid var(--warning);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--warning);
+  font-size: var(--text-sm);
+  font-weight: 700;
+  cursor: pointer;
+}
+
 .w-full {
   width: 100%;
 }

--- a/src/views/ActiveWorkoutView.jsx
+++ b/src/views/ActiveWorkoutView.jsx
@@ -15,7 +15,7 @@ import { buildSummary, findPRs } from '../utils/workoutSummary';
 import { resolveRestDuration } from '../utils/resolveRestDuration';
 import { resolveManualTimerDuration } from '../utils/resolveManualTimerDuration';
 import { shouldStartRestTimer } from '../utils/shouldStartRestTimer';
-import { buildInitialSessionLog, buildSessionExercises, hasLoggedData, applySessionIntent, setExerciseNoteIntent, setWorkoutNoteIntent, beginTargetEdit, editTargetSet, addTargetSet, removeTargetSet, confirmTargetEdit } from '../session/session';
+import { buildInitialSessionLog, buildSessionExercises, hasLoggedData, applySessionIntent, setExerciseNoteIntent, setWorkoutNoteIntent, beginTargetEdit, editTargetSet, addTargetSet, removeTargetSet, confirmTargetEdit, discardTargetEdit } from '../session/session';
 
 function findNextActiveWorkoutSet(workout, currentLog) {
   if (!workout?.blocks || !currentLog?.exercises) return null;
@@ -149,6 +149,14 @@ export default function ActiveWorkoutView({
 
   const handleAddSet = (blockIdx, exIdx) => {
     setEditBlocks((prev) => addTargetSet(prev, { blockIndex: blockIdx, exerciseIndex: exIdx }));
+  };
+
+  const handleDiscardEdits = () => {
+    // Explicit discard: drop the pending draft without touching the Workout or
+    // Template (no onUpdateWorkout call).
+    discardTargetEdit();
+    setEditMode(false);
+    setEditBlocks(null);
   };
 
   // Keep screen awake during active workout
@@ -336,6 +344,13 @@ export default function ActiveWorkoutView({
           <div className="aw-edit-banner">
             <Pencil size={13} />
             <span>Editing targets — tap the pencil again to save</span>
+            <button
+              type="button"
+              className="aw-edit-banner__discard"
+              onClick={handleDiscardEdits}
+            >
+              Discard
+            </button>
           </div>
         )}
 

--- a/src/views/ActiveWorkoutView.jsx
+++ b/src/views/ActiveWorkoutView.jsx
@@ -15,7 +15,7 @@ import { buildSummary, findPRs } from '../utils/workoutSummary';
 import { resolveRestDuration } from '../utils/resolveRestDuration';
 import { resolveManualTimerDuration } from '../utils/resolveManualTimerDuration';
 import { shouldStartRestTimer } from '../utils/shouldStartRestTimer';
-import { buildInitialSessionLog, buildSessionExercises, hasLoggedData, applySessionIntent, setExerciseNoteIntent, setWorkoutNoteIntent } from '../session/session';
+import { buildInitialSessionLog, buildSessionExercises, hasLoggedData, applySessionIntent, setExerciseNoteIntent, setWorkoutNoteIntent, beginTargetEdit, editTargetSet, addTargetSet, removeTargetSet, confirmTargetEdit } from '../session/session';
 
 function findNextActiveWorkoutSet(workout, currentLog) {
   if (!workout?.blocks || !currentLog?.exercises) return null;
@@ -123,40 +123,32 @@ export default function ActiveWorkoutView({
 
   const toggleEditMode = () => {
     if (editMode) {
-      if (editBlocks && onUpdateWorkout) onUpdateWorkout(editBlocks);
+      const change = confirmTargetEdit(editBlocks, workoutTitle);
+      if (change && onUpdateWorkout) onUpdateWorkout(change.blocks);
       setEditMode(false);
       setEditBlocks(null);
     } else {
-      setEditBlocks(JSON.parse(JSON.stringify(workout.blocks)));
+      const draft = beginTargetEdit(workout);
+      if (!draft) return;
+      setEditBlocks(draft);
       setEditMode(true);
     }
   };
 
   const handleTargetChange = (blockIdx, exIdx, setIdx, field, value) => {
-    setEditBlocks((prev) => {
-      const next = JSON.parse(JSON.stringify(prev));
-      next[blockIdx].exercises[exIdx].sets[setIdx][field] = value;
-      return next;
-    });
+    setEditBlocks((prev) =>
+      editTargetSet(prev, { blockIndex: blockIdx, exerciseIndex: exIdx, setIndex: setIdx, field, value })
+    );
   };
 
   const handleRemoveSet = (blockIdx, exIdx, setIdx) => {
-    setEditBlocks((prev) => {
-      const next = JSON.parse(JSON.stringify(prev));
-      if (next[blockIdx].exercises[exIdx].sets.length <= 1) return prev;
-      next[blockIdx].exercises[exIdx].sets.splice(setIdx, 1);
-      return next;
-    });
+    setEditBlocks((prev) =>
+      removeTargetSet(prev, { blockIndex: blockIdx, exerciseIndex: exIdx, setIndex: setIdx })
+    );
   };
 
   const handleAddSet = (blockIdx, exIdx) => {
-    setEditBlocks((prev) => {
-      const next = JSON.parse(JSON.stringify(prev));
-      const sets = next[blockIdx].exercises[exIdx].sets;
-      const base = sets[sets.length - 1] || { reps: null, weight: null, unit: 'lb' };
-      sets.push({ ...base });
-      return next;
-    });
+    setEditBlocks((prev) => addTargetSet(prev, { blockIndex: blockIdx, exerciseIndex: exIdx }));
   };
 
   // Keep screen awake during active workout


### PR DESCRIPTION
## Summary

Confirms active-Session target edits through the Session module. Target-edit
mode logic now lives as pure, testable functions in `src/session/session.js`
rather than inlined in the view.

An athlete can edit prescribed targets during a Workout and either explicitly
confirm them to the matching Workout **and** Template, or discard them with no
change to either.

Closes #67

## What changed

- **Session module (`src/session/session.js`)** — new pure functions:
  - `beginTargetEdit(workout)` — opens a deep-cloned pending draft (Session state); returns `null` for an invalid Workout.
  - `editTargetSet(draft, {blockIndex, exerciseIndex, setIndex, field, value})` — immutably edits `reps`/`weight`; ignores other fields and out-of-range coordinates.
  - `addTargetSet(draft, {blockIndex, exerciseIndex})` — appends a copy of the last prescribed Set.
  - `removeTargetSet(draft, {blockIndex, exerciseIndex, setIndex})` — removes a Set but **refuses to remove an Exercise's final Set**.
  - `confirmTargetEdit(draft, workoutTitle)` — returns a Training Plan lifecycle `syncBlocks` change; `null` when there is no draft.
  - `discardTargetEdit()` — returns `null` (no lifecycle change; neither Workout nor Template touched).
- **`ActiveWorkoutView.jsx`** — target-edit handlers (`toggleEditMode`, `handleTargetChange`, `handleAddSet`, `handleRemoveSet`) now delegate to the module functions. Confirmation still routes through the existing `syncBlocks` lifecycle path in `App.jsx`. No behavior change.

## Acceptance criteria

- [x] Target-edit mode supports reps, weight, and Set additions/removals while preventing removal of an Exercise's final Set.
- [x] Pending edits remain Session state until explicit confirmation; discard changes neither Workout nor Template.
- [x] Confirmation uses the Training Plan lifecycle authority (`applyTemplateChange` `syncBlocks`) to update the matching Workout and Template.
- [x] Module tests cover edit, confirm, and discard outcomes while existing interactions remain unchanged.

## Decisions

- Modeled the pending draft as the Parts (`blocks`) array itself (matching the view's prior `editBlocks` shape) so the refactor is a drop-in and keeps the view thin.
- `confirmTargetEdit` returns the lifecycle change descriptor rather than mutating state directly, keeping the module pure and letting `App.jsx` remain the single owner of durable writes.
- The view has no standalone "discard edit" control today (toggle-off always confirms), so `discardTargetEdit` is exercised at the module seam; the view's existing confirm-on-toggle behavior is preserved unchanged.

## Testing

- `npm run test:unit` — 617 passed (12 new target-edit module tests).
- `npm run test:e2e` — 94 passed, incl. `template-session-target-consistency` (both directions).
- `npm run build` — succeeds.
- `npm run test:e2e:visual` — captured; inspected desktop + mobile PNGs.

## Visual evidence (inspected)

- `artifacts/visual/mobile-chrome/active-workout.png` — edit pencil present, target `3 × BW` reflected, dark theme, sticky finish bar layered correctly, no overlap.
- `artifacts/visual/mobile-chrome/template-target-reflects-session-confirmation.png` — confirmed Session edit (reps `5`) propagated to the matching Template.
- `artifacts/visual/chromium/session-target-reflects-template-edit.png` — Template edit (`9 × BW`) reflected on the Session target.

## Review notes



## Review notes (dual-model)

Two `code-review` agents ran in parallel against PR #84:

**`gpt-5.5` (quality & correctness)** — 2 findings, both adopted:
- Discard not reachable from the UI → added an explicit **Discard** button to active-Session edit mode wired to `discardTargetEdit()`; new e2e journey proves it leaves the Workout and Template unchanged.
- `editTargetSet`/`removeTargetSet` accepted non-integer `setIndex` (e.g. `undefined`/`NaN`) which could coerce to `0` and remove/throw → added `Number.isInteger` bounds guard (`isSetPosition`); new module tests cover it.

**`claude-opus-4.8` (security)** — 0 findings. Confirmed the `Set(['reps','weight'])` allowlist rejects `__proto__`/`constructor`/`prototype`, so no prototype-pollution vector; coordinate indices resolve through optional chaining + `Array.isArray`; deep-clone (structuredClone / JSON round-trip without reviver) is safe.
