### PR TITLE
feat: log Sets and run rest timers through the Session module

### DIFF
--- a/src/session/session.js
+++ b/src/session/session.js
@@ -302,7 +302,10 @@ export function discardTargetEdit() {
 export function logSet(log, { exerciseTitle, setIndex, setData }) {
   if (!log || !log.exercises) return log;
   const sets = log.exercises[exerciseTitle];
-  if (!Array.isArray(sets) || setIndex < 0 || setIndex >= sets.length) return log;
+  // Allow setIndex === sets.length so a Set added via target-edit mode (which
+  // grows the Workout before the Log is reconciled) can still be appended and
+  // persisted — matching the pre-module inline behaviour.
+  if (!Array.isArray(sets) || setIndex < 0 || setIndex > sets.length) return log;
 
   return {
     ...log,

--- a/src/session/session.js
+++ b/src/session/session.js
@@ -1,4 +1,7 @@
 import { parseLogKey } from '../constants';
+import { shouldStartRestTimer } from '../utils/shouldStartRestTimer';
+import { resolveRestDuration } from '../utils/resolveRestDuration';
+import { resolveManualTimerDuration } from '../utils/resolveManualTimerDuration';
 
 /**
  * Session logging module — owns the deterministic parts of starting and
@@ -285,4 +288,141 @@ export function confirmTargetEdit(draft, workoutTitle) {
  */
 export function discardTargetEdit() {
   return null;
+}
+
+// ─── Set performance, next-Set, and rest decisions ─────────
+
+/**
+ * Record athlete performance for one prescribed Set, returning a new Session
+ * Log. Pure and immutable: the input Log and every sibling Set are shared by
+ * reference, so sequential edits chain from the latest Log without a stale
+ * snapshot overwriting an earlier one. Unknown Exercises and out-of-range Set
+ * positions return the input Log unchanged.
+ */
+export function logSet(log, { exerciseTitle, setIndex, setData }) {
+  if (!log || !log.exercises) return log;
+  const sets = log.exercises[exerciseTitle];
+  if (!Array.isArray(sets) || setIndex < 0 || setIndex >= sets.length) return log;
+
+  return {
+    ...log,
+    exercises: {
+      ...log.exercises,
+      [exerciseTitle]: [
+        ...sets.slice(0, setIndex),
+        setData,
+        ...sets.slice(setIndex + 1),
+      ],
+    },
+  };
+}
+
+/**
+ * Locate an Exercise within a Workout by title, along with the superset context
+ * a rest decision needs: whether its Part is a superset and whether the movement
+ * is the last of its superset round. Returns null when the Exercise is absent.
+ *
+ * @returns {{ exercise: object, isSuperset: boolean, isLastInSuperset: boolean }|null}
+ */
+export function findExerciseByTitle(workout, exerciseTitle) {
+  if (!workout || !Array.isArray(workout.blocks)) return null;
+  for (const block of workout.blocks) {
+    if (!block || !Array.isArray(block.exercises)) continue;
+    const idx = block.exercises.findIndex((ex) => ex.title === exerciseTitle);
+    if (idx !== -1) {
+      return {
+        exercise: block.exercises[idx],
+        isSuperset: block.exercises.length > 1,
+        isLastInSuperset: idx === block.exercises.length - 1,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Identify the next incomplete Set in performance order. Solo Parts are scanned
+ * Set-by-Set; superset Parts are interleaved round-by-round so the athlete
+ * cycles through every movement before advancing. Returns null when the Session
+ * is fully logged.
+ *
+ * @returns {{ exerciseTitle: string, setIndex: number }|null}
+ */
+export function findNextSet(workout, log) {
+  if (!workout?.blocks || !log?.exercises) return null;
+
+  for (const block of workout.blocks) {
+    if (!block || !Array.isArray(block.exercises)) continue;
+
+    if (block.exercises.length > 1) {
+      const maxSets = Math.max(
+        0,
+        ...block.exercises.map((exercise) => log.exercises[exercise.title]?.length ?? 0)
+      );
+      for (let setIdx = 0; setIdx < maxSets; setIdx++) {
+        for (const exercise of block.exercises) {
+          const loggedSet = log.exercises[exercise.title]?.[setIdx];
+          if (loggedSet && !loggedSet.completed) {
+            return { exerciseTitle: exercise.title, setIndex: setIdx };
+          }
+        }
+      }
+      continue;
+    }
+
+    for (const exercise of block.exercises) {
+      const loggedSets = log.exercises[exercise.title];
+      if (!loggedSets) continue;
+      const setIndex = loggedSets.findIndex((set) => !set.completed);
+      if (setIndex !== -1) return { exerciseTitle: exercise.title, setIndex };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Decide whether a rest timer should start when a Set's completion changes, and
+ * for how long. Owns the whole rest-eligibility policy so the view never decides
+ * it: re-fire prevention (a Set only fires once), the superset rule (rest fires
+ * only after the final movement of a round), and duration precedence
+ * (Exercise override, else global default).
+ *
+ * `firedSets` is a mutable Set of already-fired Set keys, shared with the view so
+ * unchecking then re-checking a Set does not restart rest.
+ *
+ * @returns {{ shouldStart: boolean, duration: number|null }}
+ */
+export function evaluateRest({
+  workout,
+  exerciseTitle,
+  setIndex,
+  wasCompleted,
+  isNowCompleted,
+  firedSets,
+  globalDefault,
+}) {
+  if (!shouldStartRestTimer(exerciseTitle, setIndex, wasCompleted, isNowCompleted, firedSets)) {
+    return { shouldStart: false, duration: null };
+  }
+
+  const context = findExerciseByTitle(workout, exerciseTitle);
+  const exercise = context?.exercise || {};
+  const isSuperset = context?.isSuperset || false;
+  const isLastInSuperset = context ? context.isLastInSuperset : true;
+
+  const duration = resolveRestDuration(exercise, isSuperset, globalDefault, isLastInSuperset);
+  if (duration == null) {
+    return { shouldStart: false, duration: null };
+  }
+  return { shouldStart: true, duration };
+}
+
+/**
+ * Resolve the duration for the manual rest button. Ignores superset status —
+ * the manual timer always honours the current Exercise's override, falling back
+ * to the global default.
+ */
+export function resolveManualRest(exercise, globalDefault) {
+  return resolveManualTimerDuration(exercise, globalDefault);
 }

--- a/src/session/session.test.js
+++ b/src/session/session.test.js
@@ -16,6 +16,11 @@ import {
   removeTargetSet,
   confirmTargetEdit,
   discardTargetEdit,
+  logSet,
+  findExerciseByTitle,
+  findNextSet,
+  evaluateRest,
+  resolveManualRest,
 } from './session.js';
 import { applyTemplateChange } from '../orchestrator.js';
 
@@ -543,5 +548,201 @@ describe('target-edit mode', () => {
       const workout = targetWorkout();
       expect(draft).toEqual(workout.blocks);
     });
+  });
+});
+
+// ─── Set performance, next-Set, and rest decisions ─────────
+
+// A Workout with one solo Part and one two-movement superset Part.
+function restWorkout() {
+  return {
+    title: 'Upper A',
+    blocks: [
+      {
+        exercises: [
+          { title: 'Bench Press', unit: 'lb', restDuration: 120, sets: [{ reps: 5, weight: 135 }, { reps: 5, weight: 135 }] },
+        ],
+      },
+      {
+        exercises: [
+          { title: 'Pull-Up', sets: [{ reps: 8, weight: 'BW', unit: 'reps' }] },
+          { title: 'Dip', sets: [{ reps: 10, weight: 0 }] },
+        ],
+      },
+    ],
+  };
+}
+
+function restLog() {
+  return buildInitialSessionLog({ logKey: '2026-07-04::Upper A', workout: restWorkout() });
+}
+
+describe('logSet', () => {
+  it('replaces one Set immutably, persisting actual reps and weight', () => {
+    const log = restLog();
+    const next = logSet(log, {
+      exerciseTitle: 'Bench Press',
+      setIndex: 1,
+      setData: { setIndex: 1, targetReps: 5, targetWeight: 135, unit: 'lb', actualReps: 6, actualWeight: 140, completed: true },
+    });
+
+    expect(next).not.toBe(log);
+    expect(log.exercises['Bench Press'][1].completed).toBe(false); // input untouched
+    expect(next.exercises['Bench Press'][1]).toMatchObject({ actualReps: 6, actualWeight: 140, completed: true });
+    expect(next.exercises['Bench Press'][0]).toBe(log.exercises['Bench Press'][0]); // sibling Set shared
+  });
+
+  it('chains sequential edits without overwriting earlier ones', () => {
+    const log = restLog();
+    const afterFirst = logSet(log, {
+      exerciseTitle: 'Bench Press',
+      setIndex: 0,
+      setData: { ...log.exercises['Bench Press'][0], actualReps: 5, completed: true },
+    });
+    const afterSecond = logSet(afterFirst, {
+      exerciseTitle: 'Bench Press',
+      setIndex: 1,
+      setData: { ...afterFirst.exercises['Bench Press'][1], actualReps: 5, completed: true },
+    });
+
+    expect(afterSecond.exercises['Bench Press'][0].completed).toBe(true);
+    expect(afterSecond.exercises['Bench Press'][1].completed).toBe(true);
+  });
+
+  it('returns the input Log unchanged for an unknown Exercise or out-of-range Set', () => {
+    const log = restLog();
+    expect(logSet(log, { exerciseTitle: 'Nope', setIndex: 0, setData: {} })).toBe(log);
+    expect(logSet(log, { exerciseTitle: 'Bench Press', setIndex: 9, setData: {} })).toBe(log);
+    expect(logSet(null, { exerciseTitle: 'Bench Press', setIndex: 0, setData: {} })).toBeNull();
+  });
+});
+
+describe('findExerciseByTitle', () => {
+  it('locates a solo Exercise with its superset context', () => {
+    const found = findExerciseByTitle(restWorkout(), 'Bench Press');
+    expect(found).toMatchObject({ isSuperset: false, isLastInSuperset: true });
+    expect(found.exercise.title).toBe('Bench Press');
+  });
+
+  it('flags a non-final superset movement as not last in its round', () => {
+    const found = findExerciseByTitle(restWorkout(), 'Pull-Up');
+    expect(found).toMatchObject({ isSuperset: true, isLastInSuperset: false });
+  });
+
+  it('flags the final superset movement as last in its round', () => {
+    const found = findExerciseByTitle(restWorkout(), 'Dip');
+    expect(found).toMatchObject({ isSuperset: true, isLastInSuperset: true });
+  });
+
+  it('returns null when the Exercise is absent', () => {
+    expect(findExerciseByTitle(restWorkout(), 'Nope')).toBeNull();
+  });
+});
+
+describe('findNextSet', () => {
+  it('finds the first incomplete Set in Workout order', () => {
+    const log = restLog();
+    expect(findNextSet(restWorkout(), log)).toEqual({ exerciseTitle: 'Bench Press', setIndex: 0 });
+  });
+
+  it('interleaves superset movements round-by-round', () => {
+    const workout = restWorkout();
+    let log = restLog();
+    // Complete both Bench Press Sets so the next incomplete lands in the superset.
+    log = logSet(log, { exerciseTitle: 'Bench Press', setIndex: 0, setData: { ...log.exercises['Bench Press'][0], completed: true } });
+    log = logSet(log, { exerciseTitle: 'Bench Press', setIndex: 1, setData: { ...log.exercises['Bench Press'][1], completed: true } });
+    // Now complete the first superset movement's only Set.
+    log = logSet(log, { exerciseTitle: 'Pull-Up', setIndex: 0, setData: { ...log.exercises['Pull-Up'][0], completed: true } });
+
+    expect(findNextSet(workout, log)).toEqual({ exerciseTitle: 'Dip', setIndex: 0 });
+  });
+
+  it('returns null once every Set is complete', () => {
+    const workout = restWorkout();
+    let log = restLog();
+    for (const title of ['Bench Press', 'Pull-Up', 'Dip']) {
+      log.exercises[title].forEach((s) => { s.completed = true; });
+    }
+    expect(findNextSet(workout, log)).toBeNull();
+  });
+});
+
+describe('evaluateRest', () => {
+  it('starts rest once for a completed solo Set, using the Exercise override', () => {
+    const firedSets = new Set();
+    const decision = evaluateRest({
+      workout: restWorkout(),
+      exerciseTitle: 'Bench Press',
+      setIndex: 0,
+      wasCompleted: false,
+      isNowCompleted: true,
+      firedSets,
+      globalDefault: 90,
+    });
+    expect(decision).toEqual({ shouldStart: true, duration: 120 });
+  });
+
+  it('does not re-fire when the same Set toggles completed again', () => {
+    const firedSets = new Set();
+    const args = {
+      workout: restWorkout(),
+      exerciseTitle: 'Bench Press',
+      setIndex: 0,
+      wasCompleted: false,
+      isNowCompleted: true,
+      firedSets,
+      globalDefault: 90,
+    };
+    expect(evaluateRest(args).shouldStart).toBe(true);
+    expect(evaluateRest(args).shouldStart).toBe(false);
+  });
+
+  it('does not start rest when a Set becomes incomplete', () => {
+    const decision = evaluateRest({
+      workout: restWorkout(),
+      exerciseTitle: 'Bench Press',
+      setIndex: 0,
+      wasCompleted: true,
+      isNowCompleted: false,
+      firedSets: new Set(),
+      globalDefault: 90,
+    });
+    expect(decision.shouldStart).toBe(false);
+  });
+
+  it('skips rest mid-superset but rests after the final movement', () => {
+    const midRound = evaluateRest({
+      workout: restWorkout(),
+      exerciseTitle: 'Pull-Up',
+      setIndex: 0,
+      wasCompleted: false,
+      isNowCompleted: true,
+      firedSets: new Set(),
+      globalDefault: 90,
+    });
+    expect(midRound).toEqual({ shouldStart: false, duration: null });
+
+    const roundEnd = evaluateRest({
+      workout: restWorkout(),
+      exerciseTitle: 'Dip',
+      setIndex: 0,
+      wasCompleted: false,
+      isNowCompleted: true,
+      firedSets: new Set(),
+      globalDefault: 90,
+    });
+    expect(roundEnd).toEqual({ shouldStart: true, duration: 90 });
+  });
+});
+
+describe('resolveManualRest', () => {
+  it('prefers the current Exercise override over the global default', () => {
+    expect(resolveManualRest({ restDuration: 150 }, 90)).toBe(150);
+  });
+
+  it('falls back to the global default without an Exercise or override', () => {
+    expect(resolveManualRest(null, 90)).toBe(90);
+    expect(resolveManualRest({}, 90)).toBe(90);
+    expect(resolveManualRest({ restDuration: 0 }, 90)).toBe(90);
   });
 });

--- a/src/session/session.test.js
+++ b/src/session/session.test.js
@@ -609,10 +609,21 @@ describe('logSet', () => {
     expect(afterSecond.exercises['Bench Press'][1].completed).toBe(true);
   });
 
-  it('returns the input Log unchanged for an unknown Exercise or out-of-range Set', () => {
+  it('appends a Set when setIndex equals the current length (post target-edit)', () => {
+    const log = restLog();
+    const beforeLen = log.exercises['Bench Press'].length;
+    const appended = { setIndex: beforeLen, targetReps: 5, targetWeight: 135, unit: 'lb', actualReps: 5, actualWeight: 135, completed: true };
+    const next = logSet(log, { exerciseTitle: 'Bench Press', setIndex: beforeLen, setData: appended });
+
+    expect(next.exercises['Bench Press']).toHaveLength(beforeLen + 1);
+    expect(next.exercises['Bench Press'][beforeLen]).toMatchObject({ completed: true, actualReps: 5 });
+  });
+
+  it('returns the input Log unchanged for an unknown Exercise or beyond-append Set', () => {
     const log = restLog();
     expect(logSet(log, { exerciseTitle: 'Nope', setIndex: 0, setData: {} })).toBe(log);
     expect(logSet(log, { exerciseTitle: 'Bench Press', setIndex: 9, setData: {} })).toBe(log);
+    expect(logSet(log, { exerciseTitle: 'Bench Press', setIndex: -1, setData: {} })).toBe(log);
     expect(logSet(null, { exerciseTitle: 'Bench Press', setIndex: 0, setData: {} })).toBeNull();
   });
 });

--- a/src/views/ActiveWorkoutView.jsx
+++ b/src/views/ActiveWorkoutView.jsx
@@ -12,41 +12,7 @@ import { hapticSuccess } from '../utils/haptics';
 import { findPreviousSets } from '../utils/exerciseHistory';
 import { computeSuggestion, formatOverloadHint } from '../utils/overloadSuggestion';
 import { buildSummary, findPRs } from '../utils/workoutSummary';
-import { resolveRestDuration } from '../utils/resolveRestDuration';
-import { resolveManualTimerDuration } from '../utils/resolveManualTimerDuration';
-import { shouldStartRestTimer } from '../utils/shouldStartRestTimer';
-import { buildInitialSessionLog, buildSessionExercises, hasLoggedData, applySessionIntent, setExerciseNoteIntent, setWorkoutNoteIntent, beginTargetEdit, editTargetSet, addTargetSet, removeTargetSet, confirmTargetEdit, discardTargetEdit } from '../session/session';
-
-function findNextActiveWorkoutSet(workout, currentLog) {
-  if (!workout?.blocks || !currentLog?.exercises) return null;
-
-  for (const block of workout.blocks) {
-    if (block.exercises.length > 1) {
-      const maxSets = Math.max(
-        ...block.exercises.map((exercise) => currentLog.exercises[exercise.title]?.length ?? 0)
-      );
-
-      for (let setIdx = 0; setIdx < maxSets; setIdx++) {
-        for (const exercise of block.exercises) {
-          const loggedSet = currentLog.exercises[exercise.title]?.[setIdx];
-          if (loggedSet && !loggedSet.completed) {
-            return { exerciseTitle: exercise.title, setIndex: setIdx };
-          }
-        }
-      }
-      continue;
-    }
-
-    for (const exercise of block.exercises) {
-      const loggedSets = currentLog.exercises[exercise.title];
-      if (!loggedSets) continue;
-      const setIndex = loggedSets.findIndex((set) => !set.completed);
-      if (setIndex !== -1) return { exerciseTitle: exercise.title, setIndex };
-    }
-  }
-
-  return null;
-}
+import { buildInitialSessionLog, buildSessionExercises, hasLoggedData, applySessionIntent, setExerciseNoteIntent, setWorkoutNoteIntent, beginTargetEdit, editTargetSet, addTargetSet, removeTargetSet, confirmTargetEdit, discardTargetEdit, logSet, findNextSet, evaluateRest, resolveManualRest, findExerciseByTitle } from '../session/session';
 
 export default function ActiveWorkoutView({
   logKey,
@@ -67,6 +33,20 @@ export default function ActiveWorkoutView({
     if (log) return log;
     return buildInitialSessionLog({ logKey, workout });
   });
+
+  // Mirror of the latest committed Log. Reading from this ref (instead of the
+  // `currentLog` closure) lets rapid sequential edits chain off the freshest Log
+  // so no in-flight edit is overwritten by a stale snapshot.
+  const currentLogRef = useRef(currentLog);
+  useEffect(() => { currentLogRef.current = currentLog; }, [currentLog]);
+
+  // Single commit path: update the ref synchronously, schedule the state update,
+  // and persist immediately for crash recovery.
+  const commitLog = useCallback((next) => {
+    currentLogRef.current = next;
+    setCurrentLog(next);
+    saveLog(logKey, next);
+  }, [logKey, saveLog]);
 
   const [showCancelModal, setShowCancelModal] = useState(false);
   const [showCompleteModal, setShowCompleteModal] = useState(false);
@@ -114,12 +94,12 @@ export default function ActiveWorkoutView({
 
   const scrollToNextSet = useCallback(() => {
     if (userScrolledDuringRest.current) return;
-    const next = findNextActiveWorkoutSet(workout, currentLog);
+    const next = findNextSet(workout, currentLogRef.current);
     if (!next) return;
     const escaped = CSS.escape(`${next.exerciseTitle}::${next.setIndex}`);
     const el = document.querySelector(`[data-set-id="${escaped}"]`);
     if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  }, [workout, currentLog]);
+  }, [workout]);
 
   const toggleEditMode = () => {
     if (editMode) {
@@ -201,74 +181,51 @@ export default function ActiveWorkoutView({
     }
 
     const updated = { ...currentLog, exercises: buildSessionExercises(workout) };
-    setCurrentLog(updated);
-    saveLog(logKey, updated);
+    commitLog(updated);
   }, []);
 
-  // Save log on every change (crash recovery)
+  // Save log on every change (crash recovery). All rest-eligibility and next-Set
+  // decisions run through the Session module; the view only performs effects.
   const updateExerciseSet = (exerciseTitle, setIndex, newSetData) => {
-    const wasCompleted = currentLog.exercises[exerciseTitle]?.[setIndex]?.completed;
+    const prev = currentLogRef.current;
+    const wasCompleted = prev.exercises[exerciseTitle]?.[setIndex]?.completed;
 
-    const updated = {
-      ...currentLog,
-      exercises: {
-        ...currentLog.exercises,
-        [exerciseTitle]: [
-          ...currentLog.exercises[exerciseTitle].slice(0, setIndex),
-          newSetData,
-          ...currentLog.exercises[exerciseTitle].slice(setIndex + 1),
-        ],
-      },
-    };
-    setCurrentLog(updated);
-    saveLog(logKey, updated);
+    const updated = logSet(prev, { exerciseTitle, setIndex, setData: newSetData });
+    commitLog(updated);
 
-    // Track current exercise context for manual timer
-    for (const block of workout.blocks) {
-      const found = block.exercises.find((ex) => ex.title === exerciseTitle);
-      if (found) { currentExerciseRef.current = found; break; }
-    }
+    // Track current exercise context for the manual timer.
+    const context = findExerciseByTitle(workout, exerciseTitle);
+    if (context) currentExerciseRef.current = context.exercise;
 
-    // Auto-start rest timer (superset round-aware, with re-fire prevention)
-    if (shouldStartRestTimer(exerciseTitle, setIndex, wasCompleted, newSetData.completed, firedRestTimerSets.current)) {
-      // Look up the exercise, its block, and its position within the block.
-      // In a superset, rest only fires after the last movement of the round.
-      let exercise = null;
-      let isSuperset = false;
-      let isLastInSuperset = true;
-      for (const block of workout.blocks) {
-        const idx = block.exercises.findIndex((ex) => ex.title === exerciseTitle);
-        if (idx !== -1) {
-          exercise = block.exercises[idx];
-          isSuperset = block.exercises.length > 1;
-          isLastInSuperset = idx === block.exercises.length - 1;
-          break;
-        }
-      }
-      const duration = resolveRestDuration(exercise || {}, isSuperset, settings.restDuration, isLastInSuperset);
-      if (duration != null) {
-        restTimerKey.current += 1;
-        setRestTimerDuration(duration);
-        setRestTimerActive(true);
-      }
+    // The Session module owns rest eligibility (re-fire prevention, superset
+    // round rule) and duration precedence; the view just starts the timer.
+    const rest = evaluateRest({
+      workout,
+      exerciseTitle,
+      setIndex,
+      wasCompleted,
+      isNowCompleted: newSetData.completed,
+      firedSets: firedRestTimerSets.current,
+      globalDefault: settings.restDuration,
+    });
+    if (rest.shouldStart) {
+      restTimerKey.current += 1;
+      setRestTimerDuration(rest.duration);
+      setRestTimerActive(true);
     }
   };
 
   const updateExerciseNote = (exerciseTitle, note) => {
-    const updated = applySessionIntent(currentLog, setExerciseNoteIntent(exerciseTitle, note));
-    setCurrentLog(updated);
-    saveLog(logKey, updated);
+    commitLog(applySessionIntent(currentLogRef.current, setExerciseNoteIntent(exerciseTitle, note)));
   };
 
   const updateWorkoutNote = useCallback((note) => {
-    const updated = applySessionIntent(currentLog, setWorkoutNoteIntent(note));
-    setCurrentLog(updated);
-    saveLog(logKey, updated);
-  }, [currentLog, logKey, saveLog]);
+    commitLog(applySessionIntent(currentLogRef.current, setWorkoutNoteIntent(note)));
+  }, [commitLog]);
 
   const handleCompleteWorkout = () => {
     const completed = {
-      ...currentLog,
+      ...currentLogRef.current,
       completedAt: new Date().toISOString(),
     };
     saveLog(logKey, completed);
@@ -311,7 +268,7 @@ export default function ActiveWorkoutView({
   const totalSets = allSets.length;
   const allDone = totalSets > 0 && completedSets === totalSets;
   const progressPct = totalSets > 0 ? (completedSets / totalSets) * 100 : 0;
-  const nextIncompleteSet = findNextActiveWorkoutSet(workout, currentLog);
+  const nextIncompleteSet = findNextSet(workout, currentLog);
 
   return (
     <div className="view active-workout-view">
@@ -321,7 +278,7 @@ export default function ActiveWorkoutView({
         onCancel={() => setShowCancelModal(true)}
         onTimerOpen={() => {
           restTimerKey.current += 1;
-          setRestTimerDuration(resolveManualTimerDuration(currentExerciseRef.current, settings.restDuration));
+          setRestTimerDuration(resolveManualRest(currentExerciseRef.current, settings.restDuration));
           setRestTimerActive(true);
         }}
         isEditMode={editMode}

--- a/src/views/ActiveWorkoutView.test.jsx
+++ b/src/views/ActiveWorkoutView.test.jsx
@@ -154,4 +154,34 @@ describe('ActiveWorkoutView', () => {
     expect(finalLog.exercises['Back Squat'][0].completed).toBe(true);
     expect(finalLog.exercises['Back Squat'][1].completed).toBe(true);
   });
+
+  it('logs a newly added target Set even when the Log has fewer entries than the Workout', () => {
+    // Reproduces the post target-edit state: the Workout gained a Set but the
+    // active Log has not been reconciled, so its Set array is shorter.
+    const shortLog = {
+      logKey,
+      workoutTitle: 'Full-Body Express',
+      date: '2026-07-04',
+      completedAt: null,
+      startedAt: '2026-07-04T12:00:00.000Z',
+      exercises: {
+        'Back Squat': [
+          { setIndex: 0, targetReps: 8, targetWeight: 185, unit: 'lb', actualReps: 8, actualWeight: 185, completed: true },
+        ],
+      },
+      exerciseNotes: {},
+      workoutNote: '',
+    };
+    const { saveLog } = renderActiveWorkout({
+      workouts: { [twoSetWorkout.title]: twoSetWorkout },
+      logs: { [logKey]: shortLog },
+    });
+
+    // The second (added) row has no logged entry yet; completing it must append.
+    fireEvent.click(screen.getByRole('button', { name: 'Mark complete' }));
+
+    const finalLog = saveLog.mock.calls.at(-1)[1];
+    expect(finalLog.exercises['Back Squat']).toHaveLength(2);
+    expect(finalLog.exercises['Back Squat'][1].completed).toBe(true);
+  });
 });

--- a/src/views/ActiveWorkoutView.test.jsx
+++ b/src/views/ActiveWorkoutView.test.jsx
@@ -26,6 +26,46 @@ const workout = {
   ],
 };
 
+const twoSetWorkout = {
+  title: 'Full-Body Express',
+  blocks: [
+    {
+      exercises: [
+        {
+          title: 'Back Squat',
+          unit: 'lb',
+          sets: [
+            { reps: 8, weight: 185, unit: 'lb' },
+            { reps: 8, weight: 185, unit: 'lb' },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+function twoSetLog() {
+  const set = (setIndex) => ({
+    setIndex,
+    targetReps: 8,
+    targetWeight: 185,
+    unit: 'lb',
+    actualReps: '',
+    actualWeight: '',
+    completed: false,
+  });
+  return {
+    logKey,
+    workoutTitle: 'Full-Body Express',
+    date: '2026-07-04',
+    completedAt: null,
+    startedAt: '2026-07-04T12:00:00.000Z',
+    exercises: { 'Back Squat': [set(0), set(1)] },
+    exerciseNotes: {},
+    workoutNote: '',
+  };
+}
+
 const existingLog = {
   logKey,
   workoutTitle: workout.title,
@@ -82,5 +122,36 @@ describe('ActiveWorkoutView', () => {
         workoutNote: 'Felt strong before leaving the gym.',
       })
     );
+  });
+
+  it('persists a completed Set with its actual reps and weight immediately', () => {
+    const { saveLog } = renderActiveWorkout({
+      workouts: { [twoSetWorkout.title]: twoSetWorkout },
+      logs: { [logKey]: twoSetLog() },
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Mark complete' })[0]);
+
+    const lastCall = saveLog.mock.calls.at(-1);
+    expect(lastCall[0]).toBe(logKey);
+    expect(lastCall[1].exercises['Back Squat'][0]).toMatchObject({
+      completed: true,
+      actualReps: 8,
+      actualWeight: 185,
+    });
+  });
+
+  it('does not overwrite an earlier logged Set when a later Set is completed', () => {
+    const { saveLog } = renderActiveWorkout({
+      workouts: { [twoSetWorkout.title]: twoSetWorkout },
+      logs: { [logKey]: twoSetLog() },
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Mark complete' })[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Mark complete' })[0]);
+
+    const finalLog = saveLog.mock.calls.at(-1)[1];
+    expect(finalLog.exercises['Back Squat'][0].completed).toBe(true);
+    expect(finalLog.exercises['Back Squat'][1].completed).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Set performance, next-Set identification, and rest (automatic + manual) decisions now run through the pure Session module (`src/session/session.js`). `ActiveWorkoutView` no longer independently decides rest eligibility or the next Set — it only performs the requested effects.

Closes #64

## What changed

New Session module functions (all pure, unit-tested):

- **`logSet(log, { exerciseTitle, setIndex, setData })`** — immutable Set update. Sequential edits chain off the latest Log, so no in-flight edit is overwritten by a stale snapshot.
- **`findExerciseByTitle(workout, title)`** — locates an Exercise plus its superset context (`isSuperset`, `isLastInSuperset`).
- **`findNextSet(workout, log)`** — superset-aware next incomplete Set (interleaves superset rounds; solo Parts scanned Set-by-Set).
- **`evaluateRest({ ... })`** — owns the whole rest-eligibility policy: re-fire prevention, the superset rule (rest only after the final movement of a round), and duration precedence (Exercise override → global default). Returns `{ shouldStart, duration }`.
- **`resolveManualRest(exercise, globalDefault)`** — manual timer duration precedence.

`ActiveWorkoutView`:

- Mirrors the latest committed Log in `currentLogRef` and commits through a single `commitLog` path so rapid Set edits cannot overwrite each other.
- `updateExerciseSet` delegates to `logSet` + `evaluateRest`; the view just starts the timer.
- Next-Set highlight, auto-scroll, and manual timer all delegate to the module.
- Removed the local `findNextActiveWorkoutSet` and the inline rest-eligibility branching.

## Acceptance criteria

- [x] Completing a Set immediately persists actual reps and weight; rapid edits cannot overwrite each other (`logSet` + ref mirror; view + module tests).
- [x] Rest starts once for eligible solo Sets and after the final movement in a superset round, without duplicate timers (`evaluateRest`).
- [x] Manual rest preserves current Exercise and global-default precedence (`resolveManualRest`).
- [x] The module identifies the next incomplete Set while respecting manual scrolling during rest (`findNextSet`; view keeps the scroll guard).
- [x] The wired view no longer independently decides rest eligibility or the next Set.
- [x] Relevant unit and desktop/mobile Workout tests pass.

## Decisions

- Composed the existing `shouldStartRestTimer` / `resolveRestDuration` / `resolveManualTimerDuration` utils inside the module rather than duplicating their logic, so their existing tests still cover the primitives.
- Used a `currentLogRef` mirror (synced via effect, updated synchronously in the commit path) instead of side-effecting inside a `setState` reducer, to keep rapid-edit correctness without violating React's reducer-purity guidance.

## Testing

- `npm run test:unit` — 637 passed (63 session module tests incl. 16 new; 3 ActiveWorkoutView tests).
- `npm run test:e2e` — 96 passed (chromium + mobile-chrome), 6 skipped.
- `npm run build` — succeeds.
- `npm run test:e2e:visual` — captured and inspected.

## Visual evidence (inspected)

- `artifacts/visual/chromium/active-workout.png` — NEXT badge on the first incomplete Set and current-exercise highlight driven by `findNextSet`; 0/7 progress.
- `artifacts/visual/mobile-chrome/set-row-layout-weighted-completed.png` — after completing Set 1, the module correctly marks Set 2 as NEXT and highlights it; 2/7 progress; no overflow, layout intact.

## Review notes

Dual-model review (gpt-5.5 code-quality + claude-opus-4.8 security), run in parallel against this PR:

- **Adopted (code-quality, Medium):** `logSet` originally rejected `setIndex === sets.length`, which regressed logging a Set added via target-edit mode (the Workout grows before the active Log is reconciled). Fixed `logSet` to append at end (`setIndex <= sets.length`), matching the pre-module inline `slice` behaviour. Added a module test (`appends a Set when setIndex equals the current length`) and a view regression test (`logs a newly added target Set even when the Log has fewer entries than the Workout`).
- **Security (claude-opus-4.8):** No findings. Confirmed `logSet` is not prototype-pollutable (the `Array.isArray` guard rejects inherited `__proto__`/`constructor` lookups, and writes use own-property object spread — strictly safer than the pre-refactor code), `scrollToNextSet` correctly uses `CSS.escape`, and no secrets/personal data are logged.

