### PR TITLE
Add first-class template creation flow

### DIFF
--- a/e2e/templates.e2e.js
+++ b/e2e/templates.e2e.js
@@ -70,6 +70,62 @@ test('@visual creating a new template from scratch', async ({ page }, testInfo) 
   await expect(page.getByPlaceholder('Search exercises...')).toHaveValue('Goblet Squat');
 });
 
+test('@visual creating a template with a duplicate name is rejected with visible feedback', async ({ page }, testInfo) => {
+  await gotoCleanApp(page);
+
+  await page.getByRole('button', { name: 'Library' }).click();
+  await page.getByRole('tab', { name: 'Templates' }).click();
+
+  // Seed an existing template through the same create flow.
+  await page.getByRole('button', { name: /New Template/i }).click();
+  await page.locator('#template-name').fill('Full Body A');
+  await page.getByPlaceholder('Search exercises...').fill('Goblet Squat');
+  await page.locator('#template-name').click();
+  await page.waitForTimeout(250);
+  await page.getByRole('button', { name: 'Save Template' }).click();
+  await expect(page.getByRole('button', { name: /Full Body A/ })).toBeVisible();
+
+  // Let the "Template created!" toast clear so the evidence below can only
+  // show the rejection, not a leftover success message.
+  await expect(page.locator('.toast--success')).toHaveCount(0);
+
+  // Attempt a second template that collides on name.
+  await page.getByRole('button', { name: /New Template/i }).click();
+  await page.locator('#template-name').fill('Full Body A');
+  await page.getByPlaceholder('Search exercises...').fill('Push Up');
+  await page.locator('#template-name').click();
+  await page.waitForTimeout(250);
+  await page.getByRole('button', { name: 'Save Template' }).click();
+
+  // The orchestrator's rejection must reach the user, not fail silently.
+  const errorToast = page.locator('.toast--error', {
+    hasText: 'A template with this name already exists',
+  });
+  await expect(errorToast).toBeVisible();
+
+  // The toast ends on a `forwards` fade-out keyframe, so Playwright's default
+  // `animations: 'disabled'` fast-forwards it to opacity 0 and the evidence
+  // would show an empty frame. Capture with animations live, after the 220ms
+  // fade-in has settled, so the error is legible in the screenshot.
+  await page.waitForTimeout(300);
+  await captureVisualEvidence(page, testInfo, 'template-create-duplicate-name-error', {
+    animations: 'allow',
+  });
+
+  // The editor stays open with the user's work intact so the name can be fixed.
+  await expect(page.locator('.tpl-editor')).toBeVisible();
+  await expect(page.locator('#template-name')).toHaveValue('Full Body A');
+
+  // The existing template is untouched — no overwrite, no second entry.
+  const stored = await page.evaluate(() =>
+    JSON.parse(window.localStorage.getItem('th_templates') || '{}')
+  );
+  const templates = Object.values(stored);
+  expect(templates).toHaveLength(1);
+  expect(templates[0].name).toBe('Full Body A');
+  expect(templates[0].blocks[0].exercises[0].title).toBe('Goblet Squat');
+});
+
 test('@visual populated template list retains current behavior', async ({ page }, testInfo) => {
   await gotoCleanApp(page);
   await importSampleCsv(page);

--- a/e2e/templates.e2e.js
+++ b/e2e/templates.e2e.js
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { gotoCleanApp, importSampleCsv, captureVisualEvidence } from './helpers';
 
-test('@visual empty template list shows next action and navigates to Import', async ({ page }, testInfo) => {
+test('@visual empty template list shows next actions and navigates to Import', async ({ page }, testInfo) => {
   await gotoCleanApp(page);
 
   // Navigate to Library → Templates (with zero templates)
@@ -11,25 +11,66 @@ test('@visual empty template list shows next action and navigates to Import', as
   // Empty state should be visible
   await expect(page.getByRole('heading', { name: 'No templates yet', level: 2 })).toBeVisible();
 
-  // Should explain how templates are created
-  const explanation = page.getByText(/created from imported workouts/i);
+  // Should explain both ways to get a template
+  const explanation = page.getByText(/Build a template from scratch, or import/i);
   await expect(explanation).toBeVisible();
 
-  // Should have an "Import Workout" action
+  // Should have both a "New Template" and an "Import Workout" action
+  const newTemplateBtn = page.getByRole('button', { name: /New Template/i });
   const importBtn = page.getByRole('button', { name: /Import Workout/i });
+  await expect(newTemplateBtn).toBeVisible();
   await expect(importBtn).toBeVisible();
 
-  // Capture visual evidence of empty state with action
-  await captureVisualEvidence(page, testInfo, 'templates-empty-with-action');
+  // Capture visual evidence of empty state with both actions
+  await captureVisualEvidence(page, testInfo, 'templates-empty-with-actions');
 
-  // Click the action and verify navigation to Import view
+  // Click the Import action and verify navigation to Import view
   await importBtn.click();
 
   // Should land on Import view - verify by looking for Import heading
   await expect(page.getByRole('heading', { name: 'Import TrainHeroic CSV' })).toBeVisible();
 });
 
-test('populated template list retains current behavior', async ({ page }) => {
+test('@visual creating a new template from scratch', async ({ page }, testInfo) => {
+  await gotoCleanApp(page);
+
+  await page.getByRole('button', { name: 'Library' }).click();
+  await page.getByRole('tab', { name: 'Templates' }).click();
+
+  // Start from the empty-state's New Template action
+  await page.getByRole('button', { name: /New Template/i }).click();
+
+  // Lands in the template editor, blank
+  await expect(page.locator('.tpl-editor')).toBeVisible();
+  const nameInput = page.locator('#template-name');
+  await expect(nameInput).toHaveValue('');
+
+  // Save is disabled until a name is entered
+  await expect(page.getByRole('button', { name: 'Save Template' })).toBeDisabled();
+
+  // Fill in a name and an exercise
+  await nameInput.fill('Full Body A');
+  const exerciseInput = page.getByPlaceholder('Search exercises...');
+  await exerciseInput.fill('Goblet Squat');
+  // Blur commits the typed exercise title (debounced ~200ms so a dropdown
+  // click can win instead); wait for it before saving.
+  await nameInput.click();
+  await page.waitForTimeout(250);
+
+  await captureVisualEvidence(page, testInfo, 'template-editor-new-blank-filled');
+
+  await page.getByRole('button', { name: 'Save Template' }).click();
+
+  // Back on the Templates tab, with the new template listed and toast confirming creation
+  await expect(page.getByText('Template created!')).toBeVisible();
+  await expect(page.getByRole('button', { name: /Full Body A/ })).toBeVisible();
+
+  // Re-opening it shows the saved exercise
+  await page.getByRole('button', { name: /Full Body A/ }).click();
+  await expect(page.getByPlaceholder('Search exercises...')).toHaveValue('Goblet Squat');
+});
+
+test('@visual populated template list retains current behavior', async ({ page }, testInfo) => {
   await gotoCleanApp(page);
   await importSampleCsv(page);
 
@@ -42,7 +83,13 @@ test('populated template list retains current behavior', async ({ page }) => {
 
   // Should show template rows
   await expect(page.getByRole('button', { name: /Lower Body B/ })).toBeVisible();
-  
+
+  // Should show the persistent "New Template" toolbar action
+  await expect(page.getByRole('button', { name: /New Template/i })).toBeVisible();
+
   // Should NOT show "Import Workout" button when templates exist
   await expect(page.getByRole('button', { name: /Import Workout/i })).not.toBeVisible();
+
+  await captureVisualEvidence(page, testInfo, 'templates-populated-with-new-template-toolbar');
 });
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -423,6 +423,11 @@ export default function App() {
           template={tpl}
           exerciseNames={exerciseNames}
           onSave={(updated) => {
+            // Rejections (e.g. a duplicate Template name) are surfaced by
+            // applyWrites itself via the shell's onError → error toast, and
+            // leave committed state untouched. So this only gates the success
+            // path: on failure the editor stays open with the user's work
+            // intact so the name can be corrected.
             const ok = isNew
               ? applyWrites(applyTemplateChange(snap(), {
                   type: 'create',

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -407,21 +407,35 @@ export default function App() {
       break;
 
     case ROUTE_EDIT_TEMPLATE: {
-      const tpl = templates[params.templateId];
+      // Creating a new Template reuses the same editor as editing an existing
+      // one: a blank in-memory Template seeds the form, and onSave routes to
+      // the orchestrator's `create` (with name-collision checking) instead of
+      // `save`. This keeps the create/edit UX — and its validation/discard
+      // logic — in exactly one place.
+      const isNew = !!params.isNew;
+      const tpl = isNew
+        ? { name: '', createdDate: new Date().toISOString(), blocks: [], notes: '' }
+        : templates[params.templateId];
 
       currentView = tpl ? (
         <TemplateEditorView
+          key={isNew ? 'new-template' : params.templateId}
           template={tpl}
           exerciseNames={exerciseNames}
           onSave={(updated) => {
-            const ok = applyWrites(applyTemplateChange(snap(), {
-              type: 'save',
-              template: updated,
-              previousName: tpl.name,
-            }));
+            const ok = isNew
+              ? applyWrites(applyTemplateChange(snap(), {
+                  type: 'create',
+                  workout: { title: updated.name, blocks: updated.blocks, notes: updated.notes },
+                }))
+              : applyWrites(applyTemplateChange(snap(), {
+                  type: 'save',
+                  template: updated,
+                  previousName: tpl.name,
+                }));
             if (ok) {
               navigate(ROUTE_LIBRARY, { tab: 'templates' });
-              showToast('Template saved!');
+              showToast(isNew ? 'Template created!' : 'Template saved!');
             }
           }}
           onCancel={() => navigate(ROUTE_LIBRARY, { tab: 'templates' })}

--- a/src/styles/templates.css
+++ b/src/styles/templates.css
@@ -61,6 +61,18 @@
   font-variant-numeric: tabular-nums;
 }
 
+.tpl-list__toolbar {
+  padding: 0 var(--space-lg) var(--space-md);
+}
+
+.tpl-list__new-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-xs);
+  width: 100%;
+}
+
 .tpl-list__search {
   position: sticky;
   top: 0;
@@ -128,6 +140,19 @@
   color: var(--text-secondary);
   font-size: var(--text-sm);
   text-wrap: pretty;
+}
+
+.tpl-list__empty-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  width: 100%;
+  max-width: 260px;
+  margin-top: var(--space-lg);
+}
+
+.tpl-list__empty-actions .btn {
+  width: 100%;
 }
 
 .tpl-list__swipe-container {
@@ -729,6 +754,7 @@
 
 @media (max-width: 430px) {
   .tpl-list__header,
+  .tpl-list__toolbar,
   .tpl-list__search,
   .tpl-list__items,
   .tpl-editor__header,

--- a/src/views/TemplateListView.jsx
+++ b/src/views/TemplateListView.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef } from 'react';
-import { ArrowLeft, ChevronRight, Layers3, Search, Trash2 } from 'lucide-react';
+import { ArrowLeft, ChevronRight, Layers3, Plus, Search, Trash2 } from 'lucide-react';
 import { ROUTE_SETTINGS, ROUTE_EDIT_TEMPLATE, ROUTE_IMPORT } from '../constants';
 
 const SWIPE_THRESHOLD = 80;
@@ -79,6 +79,10 @@ export default function TemplateListView({
     setDeleteTarget(id);
   };
 
+  const handleCreateNew = () => {
+    navigate(ROUTE_EDIT_TEMPLATE, { isNew: true });
+  };
+
   const confirmDelete = () => {
     if (deleteTarget) {
       deleteTemplate(deleteTarget);
@@ -88,6 +92,15 @@ export default function TemplateListView({
 
   const body = (
     <>
+      {templateList && templateList.length > 0 && (
+        <div className="tpl-list__toolbar">
+          <button className="btn btn-primary tpl-list__new-btn" onClick={handleCreateNew}>
+            <Plus size={16} />
+            New Template
+          </button>
+        </div>
+      )}
+
       {templateList && templateList.length > 5 && (
         <div className="tpl-list__search">
           <Search size={16} className="tpl-list__search-icon" />
@@ -109,16 +122,18 @@ export default function TemplateListView({
             <p>
               {search
                 ? 'Try a shorter search term.'
-                : 'Templates are created from imported workouts. Import a workout to get started.'}
+                : 'Build a template from scratch, or import an existing workout to generate one automatically.'}
             </p>
             {!search && (
-              <button
-                className="btn btn-primary"
-                onClick={() => navigate(ROUTE_IMPORT)}
-                style={{ marginTop: '1rem' }}
-              >
-                Import Workout
-              </button>
+              <div className="tpl-list__empty-actions">
+                <button className="btn btn-primary" onClick={handleCreateNew}>
+                  <Plus size={16} />
+                  New Template
+                </button>
+                <button className="btn btn-secondary" onClick={() => navigate(ROUTE_IMPORT)}>
+                  Import Workout
+                </button>
+              </div>
             )}
           </div>
         ) : (

--- a/src/views/TemplateListView.test.jsx
+++ b/src/views/TemplateListView.test.jsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import TemplateListView from './TemplateListView.jsx';
+
+const templateList = [
+  { id: 'tpl_1', name: 'Push Day', blocks: [{ exercises: [{ title: 'Bench Press', sets: [] }] }] },
+];
+
+function renderView(overrides = {}) {
+  const props = {
+    templateList,
+    deleteTemplate: vi.fn(),
+    navigate: vi.fn(),
+    embedded: true,
+    ...overrides,
+  };
+  return { ...render(<TemplateListView {...props} />), props };
+}
+
+describe('TemplateListView — creating a new template', () => {
+  it('offers a discoverable New Template action alongside existing templates', () => {
+    renderView();
+    expect(screen.getByRole('button', { name: /new template/i })).toBeTruthy();
+  });
+
+  it('navigates to the template editor in create mode when tapped', () => {
+    const { props } = renderView();
+    fireEvent.click(screen.getByRole('button', { name: /new template/i }));
+    expect(props.navigate).toHaveBeenCalledWith('editTemplate', { isNew: true });
+  });
+
+  it('still offers the New Template action from the empty state', () => {
+    const { props } = renderView({ templateList: [] });
+    expect(screen.getByText('No templates yet')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /new template/i }));
+    expect(props.navigate).toHaveBeenCalledWith('editTemplate', { isNew: true });
+  });
+
+  it('keeps the Import Workout action available from the empty state', () => {
+    renderView({ templateList: [] });
+    expect(screen.getByRole('button', { name: /import workout/i })).toBeTruthy();
+  });
+
+  it('does not show the New Template action twice when the list is empty', () => {
+    renderView({ templateList: [] });
+    expect(screen.getAllByRole('button', { name: /new template/i })).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- add discoverable New Template actions for empty and populated template libraries
- reuse the existing template editor and orchestration create path
- surface and regression-test duplicate-name rejection without overwriting user work

## Validation
- 651 unit tests passed
- 102 Playwright tests passed across desktop and mobile, with 6 conditional skips
- production build succeeded
- desktop and mobile visual evidence inspected
