### PR TITLE
Fix deferred exercise-title edits overwriting template changes

### DIFF
--- a/e2e/template-editor.e2e.js
+++ b/e2e/template-editor.e2e.js
@@ -211,4 +211,59 @@ test.describe('Template Editor @visual', () => {
     await expect(page.locator('text=Unsaved changes')).toBeVisible();
     await captureVisualEvidence(page, testInfo, 'unsaved-after-set-change');
   });
+
+  test('@visual typing a free-text exercise title and immediately entering reps preserves both, with no artificial wait (issue #88)', async ({ page }, testInfo) => {
+    await gotoCleanApp(page);
+    await importSampleCsv(page);
+
+    await page.click('text=Library');
+    await page.click('button[role="tab"]:has-text("Templates")');
+    await page.click('text=Push Day');
+
+    const titleInput = page.locator('.tpl-editor__exercise-picker input').first();
+    const repsInput = page.locator('.tpl-editor__set-input').first();
+
+    // Type a free-text title (not a dropdown selection) and, without waiting
+    // for the deferred blur commit, click straight into the next field and
+    // enter a value. This is the exact "type title -> immediately act" path
+    // from issue #88; no waitForTimeout/blur workaround is used.
+    await titleInput.fill('Zercher Squat');
+    await repsInput.click();
+    await repsInput.fill('12');
+
+    // Both edits must survive the deferred title commit.
+    await expect(repsInput).toHaveValue('12');
+    await expect(titleInput).toHaveValue('Zercher Squat');
+    await captureVisualEvidence(page, testInfo, 'free-text-title-and-reps-preserved');
+
+    // Persist through a full save -> reopen round trip (the template's own
+    // name is unchanged, so reopen it by that name).
+    await page.click('button:has-text("Save Template")');
+    await expect(page.locator('button[role="tab"]:has-text("Templates")')).toBeVisible();
+    await page.click('text=Push Day');
+    await expect(page.locator('.tpl-editor__exercise-picker input').first()).toHaveValue('Zercher Squat');
+    await expect(page.locator('.tpl-editor__set-input').first()).toHaveValue('12');
+    await captureVisualEvidence(page, testInfo, 'free-text-title-and-reps-persisted-after-reopen');
+  });
+
+  test('@visual typing a free-text exercise title and immediately clicking Add Exercise to Part keeps both (issue #88)', async ({ page }, testInfo) => {
+    await gotoCleanApp(page);
+    await importSampleCsv(page);
+
+    await page.click('text=Library');
+    await page.click('button[role="tab"]:has-text("Templates")');
+    await page.click('text=Push Day');
+
+    const titleInput = page.locator('.tpl-editor__exercise-picker input').first();
+    const exerciseCountBefore = await page.locator('.tpl-editor__exercise').count();
+
+    await titleInput.fill('Landmine Press');
+    await page.getByRole('button', { name: 'Add Exercise to Part' }).first().click();
+
+    // The click must add the exercise AND the typed title must survive the
+    // deferred commit — neither the click nor the title may be swallowed.
+    await expect(page.locator('.tpl-editor__exercise')).toHaveCount(exerciseCountBefore + 1);
+    await expect(titleInput).toHaveValue('Landmine Press');
+    await captureVisualEvidence(page, testInfo, 'free-text-title-and-added-exercise-preserved');
+  });
 });

--- a/src/views/TemplateEditorView.jsx
+++ b/src/views/TemplateEditorView.jsx
@@ -118,17 +118,47 @@ export default function TemplateEditorView({ template, exerciseNames, onSave, on
   }
 
   function setExerciseTitle(bIdx, eIdx, title) {
-    const next = [...blocks];
-    next[bIdx] = {
-      ...next[bIdx],
-      exercises: next[bIdx].exercises.map((ex, i) =>
-        i === eIdx ? { ...ex, title } : ex
-      ),
-    };
-    setBlocks(next);
+    // This commit can fire from a deferred onBlur timeout (see the exercise
+    // title input below), so it must merge into whatever state is current
+    // when it runs rather than overwrite a snapshot captured earlier —
+    // otherwise it silently discards any edit made during the delay window.
+    setBlocks((prevBlocks) => {
+      const next = [...prevBlocks];
+      next[bIdx] = {
+        ...next[bIdx],
+        exercises: next[bIdx].exercises.map((ex, i) =>
+          i === eIdx ? { ...ex, title } : ex
+        ),
+      };
+      return next;
+    });
     setActiveSearch(null);
     setSearchQuery('');
   }
+
+  // Merges any not-yet-committed free-text exercise title into `sourceBlocks`
+  // and returns the result. Used to flush the pending onBlur commit
+  // synchronously (e.g. before Save reads `blocks`) instead of waiting for
+  // the 200ms timeout, so a fast Save right after typing can't read stale
+  // state and discard the title.
+  function flushPendingExerciseTitle(sourceBlocks) {
+    const curActive = activeSearchRef.current;
+    if (!curActive) return sourceBlocks;
+    const { blockIdx: bIdx, exIdx: eIdx } = curActive;
+    const curQuery = searchQueryRef.current.trim();
+    const currentTitle = sourceBlocks[bIdx]?.exercises?.[eIdx]?.title;
+    if (!curQuery || curQuery === currentTitle) return sourceBlocks;
+
+    const next = [...sourceBlocks];
+    next[bIdx] = {
+      ...next[bIdx],
+      exercises: next[bIdx].exercises.map((ex, i) =>
+        i === eIdx ? { ...ex, title: curQuery } : ex
+      ),
+    };
+    return next;
+  }
+
 
   function setExerciseNotes(bIdx, eIdx, workoutNotes) {
     const next = [...blocks];
@@ -263,7 +293,14 @@ export default function TemplateEditorView({ template, exerciseNames, onSave, on
   }
 
   function handleSave() {
-    const { cleanBlocks, discardedCount, error } = validateTemplate(name, blocks);
+    const flushedBlocks = flushPendingExerciseTitle(blocks);
+    if (flushedBlocks !== blocks) {
+      setBlocks(flushedBlocks);
+      setActiveSearch(null);
+      setSearchQuery('');
+    }
+
+    const { cleanBlocks, discardedCount, error } = validateTemplate(name, flushedBlocks);
 
     if (error) {
       showToast(error, 'error');

--- a/src/views/TemplateEditorView.test.jsx
+++ b/src/views/TemplateEditorView.test.jsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import TemplateEditorView from './TemplateEditorView.jsx';
+import { ToastProvider } from '../components/Toast';
+
+// Regression coverage for issue #88: the exercise-title field commits free-typed
+// text through a delayed onBlur handler (200ms, to let a dropdown click land
+// first). That deferred commit must merge into whatever state is current when
+// the timer fires, not overwrite a stale snapshot captured when the blur was
+// scheduled.
+
+function emptyTemplate() {
+  return { id: 'tpl-1', name: 'Test Template', blocks: [] };
+}
+
+function renderEditor(props = {}) {
+  const onSave = vi.fn();
+  const onCancel = vi.fn();
+  render(
+    <ToastProvider>
+      <TemplateEditorView
+        template={emptyTemplate()}
+        exerciseNames={['Back Squat', 'Overhead Press']}
+        onSave={onSave}
+        onCancel={onCancel}
+        {...props}
+      />
+    </ToastProvider>
+  );
+  return { onSave, onCancel };
+}
+
+describe('TemplateEditorView deferred exercise-title commit', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('preserves a reps value entered immediately after typing a free-text title', () => {
+    renderEditor();
+
+    const titleInput = screen.getByPlaceholderText('Search exercises...');
+    fireEvent.focus(titleInput);
+    fireEvent.change(titleInput, { target: { value: 'Barbell Bench Press' } });
+    fireEvent.blur(titleInput);
+
+    // Before the deferred blur commit fires, enter a reps value for the
+    // (still untitled) exercise's first set.
+    const repsInput = screen.getAllByPlaceholderText('-')[0];
+    fireEvent.change(repsInput, { target: { value: '8' } });
+
+    // Let the deferred title commit run.
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(repsInput.value).toBe('8');
+    expect(screen.getByDisplayValue('Barbell Bench Press')).toBeTruthy();
+  });
+
+  it('keeps a newly added exercise (and the typed title) after clicking Add Exercise to Part', () => {
+    renderEditor();
+
+    const titleInput = screen.getByPlaceholderText('Search exercises...');
+    fireEvent.focus(titleInput);
+    fireEvent.change(titleInput, { target: { value: 'Overhead Press' } });
+    fireEvent.blur(titleInput);
+
+    // Before the deferred blur commit fires, add a second exercise to the part.
+    fireEvent.click(screen.getByText('Add Exercise to Part'));
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.getAllByPlaceholderText('Search exercises...')).toHaveLength(2);
+    expect(screen.getByDisplayValue('Overhead Press')).toBeTruthy();
+  });
+
+  it('commits a pending free-text title before saving, even if Save is clicked before the deferred commit fires', () => {
+    const { onSave } = renderEditor();
+
+    const titleInput = screen.getByPlaceholderText('Search exercises...');
+    fireEvent.focus(titleInput);
+    fireEvent.change(titleInput, { target: { value: 'Zercher Squat' } });
+    fireEvent.blur(titleInput);
+
+    // Click Save immediately — before the 200ms deferred title commit fires.
+    fireEvent.click(screen.getByText('Save Template'));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.blocks[0].exercises[0].title).toBe('Zercher Squat');
+  });
+
+  it('still commits immediately when an exercise is selected from the dropdown', () => {
+    renderEditor();
+
+    const titleInput = screen.getByPlaceholderText('Search exercises...');
+    fireEvent.focus(titleInput);
+    fireEvent.change(titleInput, { target: { value: 'Back' } });
+
+    fireEvent.mouseDown(screen.getByText('Back Squat'));
+
+    // No timer advance needed — dropdown selection commits synchronously.
+    expect(screen.getByDisplayValue('Back Squat')).toBeTruthy();
+  });
+});

--- a/src/views/TemplateEditorView.test.jsx
+++ b/src/views/TemplateEditorView.test.jsx
@@ -81,6 +81,46 @@ describe('TemplateEditorView deferred exercise-title commit', () => {
     expect(screen.getByDisplayValue('Overhead Press')).toBeTruthy();
   });
 
+  it('keeps a newly added set (and the typed title) after clicking + Set', () => {
+    renderEditor();
+
+    const titleInput = screen.getByPlaceholderText('Search exercises...');
+    fireEvent.focus(titleInput);
+    fireEvent.change(titleInput, { target: { value: 'Lateral Raise' } });
+    fireEvent.blur(titleInput);
+
+    // Before the deferred blur commit fires, add a second set to this exercise.
+    const setsBefore = screen.getAllByPlaceholderText('-').length;
+    fireEvent.click(screen.getByText('+ Set'));
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.getAllByPlaceholderText('-').length).toBeGreaterThan(setsBefore);
+    expect(screen.getByDisplayValue('Lateral Raise')).toBeTruthy();
+  });
+
+  it('keeps a newly added part (and the typed title) after clicking Add Part', () => {
+    renderEditor();
+
+    const titleInput = screen.getByPlaceholderText('Search exercises...');
+    fireEvent.focus(titleInput);
+    fireEvent.change(titleInput, { target: { value: 'Front Squat' } });
+    fireEvent.blur(titleInput);
+
+    // Before the deferred blur commit fires, add a second part/block.
+    const titlesBefore = screen.getAllByPlaceholderText('Search exercises...').length;
+    fireEvent.click(screen.getByText('Add Part'));
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(screen.getAllByPlaceholderText('Search exercises...').length).toBeGreaterThan(titlesBefore);
+    expect(screen.getByDisplayValue('Front Squat')).toBeTruthy();
+  });
+
   it('commits a pending free-text title before saving, even if Save is clicked before the deferred commit fires', () => {
     const { onSave } = renderEditor();
 


### PR DESCRIPTION
Closes #88

## Summary
- merge deferred free-text exercise-title commits into the latest editor state
- flush pending titles before save so immediate saves retain the exercise
- add regression coverage for immediate reps, Add Exercise, + Set, Add Part, dropdown selection, and save/reopen flows

## Review
- Standards: no hard violations; non-blocking smell observations left out of scope
- Spec: all actionable acceptance criteria covered; the referenced pre-existing 250ms workaround does not exist on main or this branch

## Validation
- 652 unit tests passed
- 102 Playwright tests passed across desktop and mobile, with 6 conditional skips
- production build succeeded
- desktop/mobile evidence inspected
