### PR TITLE
Add safe merge-only workout imports

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# TrainLog
+
+TrainLog preserves a personal training program as reusable workouts and scheduled training sessions.
+
+## Language
+
+**Merge-only import**:
+A partial TrainHeroic import that adds reusable templates and scheduled dates without removing existing data.
+_Avoid_: Re-import, additive import
+
+**Template conflict**:
+An imported template and an existing template that share the same name but may contain different workout definitions. A conflict remains unresolved until the user chooses which definition or name to keep.
+_Avoid_: Duplicate
+
+**Import report**:
+The current merge-only import's categorized record of imported items, items already present, and unresolved template or schedule conflicts.
+_Avoid_: Import results
+
+**Template**:
+A reusable workout definition that is not tied to a date.
+_Avoid_: Workout
+
+**Scheduled workout**:
+A reusable workout definition assigned to a specific calendar date and ready to run.
+_Avoid_: Schedule entry
+
+**Schedule conflict**:
+An imported scheduled workout and an existing scheduled workout assigned to the same date with different templates. A conflict remains unresolved until the user chooses which scheduled workout to keep.
+_Avoid_: Duplicate date

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Then open http://localhost:5173 in your browser.
 
 ### 3. Import Your Data
 
-Click the **Import** tab, select your TrainHeroic CSV export, review the summary, and confirm.
+Open **Settings → Re-import CSV** (or **Templates → Import Workout**) and select a
+TrainHeroic CSV export. **Merge safely** is the default: it adds new templates and
+scheduled dates without removing existing data, then reports exact matches and
+name/date conflicts for review. Use **Replace all workouts and schedule** only
+with a complete export; TrainLog shows the affected counts before confirming.
 
 ## Build for Production
 

--- a/e2e/helpers.js
+++ b/e2e/helpers.js
@@ -38,7 +38,9 @@ export async function gotoCleanApp(page) {
 export async function importSampleCsv(page) {
   await page.locator('input[type="file"]').setInputFiles(sampleCsvPath);
   await expect(page.getByRole('heading', { name: 'Ready to import' })).toBeVisible();
-  await page.getByRole('button', { name: 'Import Data' }).click();
+  await page.getByRole('button', { name: 'Merge safely' }).click();
+  await expect(page.getByRole('heading', { name: 'Import report' })).toBeVisible();
+  await page.getByRole('button', { name: 'Done' }).click();
   await expect(page.getByRole('heading', { name: /Good (morning|afternoon|evening)/ })).toBeVisible();
 }
 

--- a/e2e/import-smoke.e2e.js
+++ b/e2e/import-smoke.e2e.js
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { gotoCleanApp, importSampleCsv } from './helpers';
+import {
+  captureVisualEvidence,
+  expectNoDocumentHorizontalOverflow,
+  gotoCleanApp,
+  importSampleCsv,
+} from './helpers';
 
 test('imports sample CSV and populates core app surfaces', async ({ page }) => {
   await gotoCleanApp(page);
@@ -16,4 +21,26 @@ test('imports sample CSV and populates core app surfaces', async ({ page }) => {
   await page.getByRole('tab', { name: 'Templates' }).click();
   await expect(page.getByLabel('4 templates')).toBeVisible();
   await expect(page.getByRole('button', { name: /Upper Body A/ })).toBeVisible();
+});
+
+test('reviews safe import conflicts before changing existing data @visual', async ({ page }, testInfo) => {
+  await gotoCleanApp(page);
+  await importSampleCsv(page);
+
+  await page.getByRole('button', { name: 'Settings' }).click();
+  await page.getByRole('button', { name: 'Re-import CSV' }).click();
+  await page.getByLabel('Paste CSV').fill(
+    `WorkoutTitle,ScheduledDate,ExerciseTitle,ExerciseData
+Upper Body A,2026-03-24,Bench Press,10 rep x 135 pound`
+  );
+  await page.getByRole('button', { name: 'Preview pasted CSV' }).click();
+  await page.getByRole('button', { name: 'Merge safely' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Import report' })).toBeVisible();
+  await expect(page.getByText('Needs choice')).toBeVisible();
+  await expect(page.getByLabel('Send feedback')).toHaveCount(0);
+  await page.getByText('Compare workout definitions').click();
+  await expect(page.getByText(/10 reps @ 135/i)).toBeVisible();
+  await expectNoDocumentHorizontalOverflow(page);
+  await captureVisualEvidence(page, testInfo, 'safe import conflict report');
 });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,14 @@ import { useTemplates } from './hooks/useTemplates';
 import { useSync } from './hooks/useSync';
 import { retryReplication, clearByKeys, coordinateSyncReload } from './storage/authority';
 import { useToast } from './components/Toast';
-import { applyTemplateChange, applyScheduleChange, applyNoteChange, applyImport } from './orchestrator';
+import {
+  applyTemplateChange,
+  applyScheduleChange,
+  applyNoteChange,
+  applyImport,
+  applyMergeImport,
+  resolveImportConflict,
+} from './orchestrator';
 import { useTrainingPlanShell } from './hooks/useTrainingPlanShell';
 import {
   ROUTE_IMPORT,
@@ -284,11 +291,25 @@ export default function App() {
     case ROUTE_IMPORT:
       currentView = (
         <ImportView
-          onImport={(workoutMap, scheduleMap) => {
+          onMergeImport={(workoutMap, scheduleMap) => {
+            const result = applyMergeImport(snap(), workoutMap, scheduleMap);
+            applyWrites(result);
+            return result.report;
+          }}
+          onResolveConflict={(report, resolution) => {
+            const result = resolveImportConflict(snap(), report, resolution);
+            return applyWrites(result) ? result.report : report;
+          }}
+          onReplaceImport={(workoutMap, scheduleMap) => {
             applyWrites(applyImport(snap(), workoutMap, scheduleMap));
             navigate(ROUTE_TRAINING);
             const count = Object.keys(workoutMap).length;
-            showToast(`Imported ${count} workout${count !== 1 ? 's' : ''} as templates!`);
+            showToast(`Replaced workout data with ${count} imported template${count !== 1 ? 's' : ''}.`);
+          }}
+          onDone={() => navigate(ROUTE_TRAINING)}
+          existingCounts={{
+            workouts: Object.keys(workouts).length,
+            scheduledDates: Object.keys(schedule).length,
           }}
         />
       );
@@ -481,7 +502,7 @@ export default function App() {
         />
       )}
 
-      {view !== ROUTE_ACTIVE_WORKOUT && view !== ROUTE_SETTINGS && view !== ROUTE_EDIT_TEMPLATE && view !== ROUTE_EXERCISE_HISTORY && !isInlineEditorActive && (
+      {view !== ROUTE_ACTIVE_WORKOUT && view !== ROUTE_IMPORT && view !== ROUTE_SETTINGS && view !== ROUTE_EDIT_TEMPLATE && view !== ROUTE_EXERCISE_HISTORY && !isInlineEditorActive && (
         <button
           className="feedback-fab"
           onClick={() => setShowFeedback(true)}

--- a/src/orchestrator.js
+++ b/src/orchestrator.js
@@ -40,6 +40,144 @@ function findTemplateByName(templates, name) {
   return Object.values(templates).find((t) => t.name === name);
 }
 
+function normalizeImportName(name) {
+  return String(name || '').trim().replace(/\s+/g, ' ').toLocaleLowerCase();
+}
+
+function displayImportName(name) {
+  return String(name || '').trim().replace(/\s+/g, ' ');
+}
+
+function findTemplateByNormalizedName(templates, name) {
+  const normalized = normalizeImportName(name);
+  return Object.values(templates).find((template) =>
+    normalizeImportName(template.name) === normalized
+  );
+}
+
+function comparableImportDefinition(value) {
+  if (Array.isArray(value)) {
+    return value.map(comparableImportDefinition);
+  }
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  return Object.keys(value)
+    .filter((key) =>
+      key !== 'workoutNotes' &&
+      value[key] !== undefined
+    )
+    .sort()
+    .reduce((result, key) => {
+      result[key] = comparableImportDefinition(value[key]);
+      return result;
+    }, {});
+}
+
+function importDefinitionsMatch(existingTemplate, importedWorkout) {
+  return JSON.stringify(comparableImportDefinition({
+    blocks: existingTemplate.blocks,
+    notes: existingTemplate.notes || '',
+  })) === JSON.stringify(comparableImportDefinition({
+    blocks: importedWorkout.blocks,
+    notes: importedWorkout.notes || '',
+  }));
+}
+
+function importedDatesFor(scheduleMap, importedName) {
+  const normalized = normalizeImportName(importedName);
+  return Object.entries(scheduleMap)
+    .filter(([, title]) => normalizeImportName(title) === normalized)
+    .map(([date]) => date)
+    .sort();
+}
+
+function loggedWorkoutForDate(logs, date) {
+  const prefix = `${date}::`;
+  const key = Object.keys(logs).find((logKey) => logKey.startsWith(prefix));
+  return key ? key.slice(prefix.length) : null;
+}
+
+function suggestImportedName(templates, importedName) {
+  const base = `${displayImportName(importedName)} (Imported)`;
+  let suggestion = base;
+  let suffix = 2;
+  while (findTemplateByNormalizedName(templates, suggestion)) {
+    suggestion = `${base} ${suffix}`;
+    suffix++;
+  }
+  return suggestion;
+}
+
+function preserveWorkoutSpecificNotes(existingTemplate, importedWorkout) {
+  const notesByExercise = new Map();
+  existingTemplate.blocks.forEach((block) => {
+    block.exercises.forEach((exercise) => {
+      if (exercise.workoutNotes) {
+        notesByExercise.set(normalizeImportName(exercise.title), exercise.workoutNotes);
+      }
+
+    });
+  });
+
+  return importedWorkout.blocks.map((block) => ({
+    ...deepClone(block),
+    exercises: block.exercises.map((exercise) => {
+      const workoutNotes = notesByExercise.get(normalizeImportName(exercise.title));
+      return workoutNotes ? { ...deepClone(exercise), workoutNotes } : deepClone(exercise);
+    }),
+  }));
+}
+
+function propagateImportedExerciseNotes(collection, importedBlocks) {
+  const importedNotes = new Map();
+  importedBlocks.forEach((block) => {
+    block.exercises.forEach((exercise) => {
+      if (exercise.notes) {
+        importedNotes.set(normalizeImportName(exercise.title), exercise.notes);
+      }
+    });
+  });
+  if (!importedNotes.size) return collection;
+
+  return Object.fromEntries(Object.entries(collection).map(([key, item]) => [
+    key,
+    {
+      ...item,
+      blocks: item.blocks.map((block) => ({
+        ...block,
+        exercises: block.exercises.map((exercise) => {
+          const notes = importedNotes.get(normalizeImportName(exercise.title));
+          return notes ? { ...exercise, notes } : exercise;
+        }),
+      })),
+    },
+  ]));
+}
+
+function inheritExistingExerciseNotes(importedBlocks, templates, workouts) {
+  const existingNotes = new Map();
+  [...Object.values(templates), ...Object.values(workouts)].forEach((item) => {
+    item.blocks.forEach((block) => {
+      block.exercises.forEach((exercise) => {
+        if (exercise.notes) {
+          existingNotes.set(normalizeImportName(exercise.title), exercise.notes);
+        }
+      });
+    });
+  });
+
+  return importedBlocks.map((block) => ({
+    ...block,
+    exercises: block.exercises.map((exercise) => {
+      if (exercise.notes) return exercise;
+      const notes = existingNotes.get(normalizeImportName(exercise.title));
+      return notes ? { ...exercise, notes } : exercise;
+    }),
+  }));
+}
+
 // Deep, reference-free copy of a JSON-serializable value so a duplicated
 // Template shares no nested objects (Parts, Exercises, Sets, notes) with its
 // source. `structuredClone` is available in supported browsers and Node ≥17;
@@ -373,6 +511,7 @@ export function applyImport(snap, workoutMap, scheduleMap, opts = {}) {
         notes: workout.notes || '',
       };
     }
+
     idx++;
   });
 
@@ -381,4 +520,235 @@ export function applyImport(snap, workoutMap, scheduleMap, opts = {}) {
     schedule: scheduleMap,
     templates: updatedTemplates,
   };
+}
+
+export function applyMergeImport(snap, workoutMap, scheduleMap, opts = {}) {
+  const { makeId } = opts;
+  let templates = { ...snap.templates };
+  let workouts = { ...snap.workouts };
+  const schedule = { ...snap.schedule };
+  const imported = [];
+  const alreadyPresent = [];
+  const templateConflicts = [];
+  const scheduleConflicts = [];
+
+  Object.values(workoutMap).forEach((sourceWorkout, index) => {
+    const workout = {
+      ...sourceWorkout,
+      blocks: inheritExistingExerciseNotes(sourceWorkout.blocks, templates, workouts),
+    };
+    const importedName = displayImportName(workout.title);
+    const dates = importedDatesFor(scheduleMap, workout.title);
+    const existingTemplate = findTemplateByNormalizedName(templates, importedName);
+    const targetName = existingTemplate ? existingTemplate.name : importedName;
+
+    let templateConflict = null;
+    let resultRecord = null;
+    if (existingTemplate) {
+      if (importDefinitionsMatch(existingTemplate, workout)) {
+        resultRecord = { name: existingTemplate.name, dates: [] };
+        alreadyPresent.push(resultRecord);
+      } else {
+        templateConflict = {
+          id: `template:${existingTemplate.name}`,
+          existingName: existingTemplate.name,
+          importedName,
+          importedDates: dates,
+          mergedDates: [],
+          retargetDates: [],
+          suggestedName: suggestImportedName(templates, importedName),
+          existingTemplate: deepClone(existingTemplate),
+          importedWorkout: { ...deepClone(workout), title: importedName },
+        };
+        templateConflicts.push(templateConflict);
+      }
+      if (!workouts[existingTemplate.name]) {
+        workouts[existingTemplate.name] = workoutFromTemplate(existingTemplate);
+      }
+    } else {
+      const id = makeId ? makeId(index) : `tpl_${Date.now()}_${index}`;
+      templates[id] = {
+        id,
+        name: importedName,
+        createdDate: new Date().toISOString(),
+        blocks: workout.blocks,
+        notes: workout.notes || '',
+      };
+      workouts[importedName] = { ...workout, title: importedName };
+      resultRecord = { name: importedName, dates: [] };
+      imported.push(resultRecord);
+      templates = propagateImportedExerciseNotes(templates, workout.blocks);
+      workouts = propagateImportedExerciseNotes(workouts, workout.blocks);
+    }
+
+    dates.forEach((date) => {
+      const scheduledTitle = snap.schedule[date];
+      const loggedTitle = loggedWorkoutForDate(snap.logs, date);
+      const scheduleCollision = scheduledTitle &&
+        normalizeImportName(scheduledTitle) !== normalizeImportName(targetName);
+      const completedHistoryConflict = loggedTitle && (
+        !scheduledTitle ||
+        normalizeImportName(loggedTitle) !== normalizeImportName(targetName)
+      );
+      if (scheduleCollision || completedHistoryConflict) {
+        const existingTitle = scheduleCollision ? scheduledTitle : loggedTitle;
+        scheduleConflicts.push({
+          id: `schedule:${date}`,
+          date,
+          existingTitle,
+          importedTitle: targetName,
+          sourceTemplateConflictId: existingTemplate &&
+            !importDefinitionsMatch(existingTemplate, workout)
+            ? `template:${existingTemplate.name}`
+            : null,
+          completed: Boolean(loggedTitle),
+        });
+        return;
+      }
+      schedule[date] = targetName;
+      resultRecord?.dates.push(date);
+      if (templateConflict && !snap.schedule[date]) {
+        templateConflict.retargetDates.push(date);
+      }
+      templateConflict?.mergedDates.push(date);
+    });
+  });
+
+  return {
+    templates,
+    workouts,
+    schedule,
+    report: {
+      imported,
+      alreadyPresent,
+      templateConflicts,
+      scheduleConflicts,
+    },
+  };
+}
+
+export function resolveImportConflict(snap, report, resolution) {
+  const nextReport = deepClone(report);
+
+  if (resolution.kind === 'template') {
+    const conflict = nextReport.templateConflicts.find(({ id }) => id === resolution.id);
+    if (!conflict) return { error: 'Template import conflict not found' };
+
+    let templates = { ...snap.templates };
+    let workouts = { ...snap.workouts };
+    const schedule = { ...snap.schedule };
+    const existingTemplate = findTemplateByNormalizedName(templates, conflict.existingName);
+    if (!existingTemplate) return { error: 'Existing template not found' };
+
+    if (resolution.action === 'keep') {
+      nextReport.alreadyPresent.push({
+        name: conflict.existingName,
+        dates: conflict.mergedDates,
+        resolution: 'Kept existing',
+      });
+    } else if (resolution.action === 'replace') {
+      const blocks = preserveWorkoutSpecificNotes(existingTemplate, conflict.importedWorkout);
+      templates[existingTemplate.id] = {
+        ...existingTemplate,
+        blocks,
+        notes: conflict.importedWorkout.notes || '',
+      };
+      workouts[existingTemplate.name] = {
+        ...deepClone(conflict.importedWorkout),
+        title: existingTemplate.name,
+        blocks,
+      };
+      templates = propagateImportedExerciseNotes(templates, conflict.importedWorkout.blocks);
+      workouts = propagateImportedExerciseNotes(workouts, conflict.importedWorkout.blocks);
+      nextReport.imported.push({
+        name: existingTemplate.name,
+        dates: conflict.mergedDates,
+        resolution: 'Replaced existing',
+      });
+    } else if (resolution.action === 'rename') {
+      const newName = displayImportName(resolution.newName);
+      if (!newName) return { error: 'Enter a name for the imported template' };
+      if (findTemplateByNormalizedName(templates, newName)) {
+        return { error: `A template named "${newName}" already exists` };
+      }
+      const id = resolution.makeId
+        ? resolution.makeId()
+        : `tpl_${Date.now()}_${Object.keys(templates).length}`;
+      templates[id] = {
+        id,
+        name: newName,
+        createdDate: new Date().toISOString(),
+        blocks: deepClone(conflict.importedWorkout.blocks),
+        notes: conflict.importedWorkout.notes || '',
+      };
+      workouts[newName] = {
+        ...deepClone(conflict.importedWorkout),
+        title: newName,
+      };
+      templates = propagateImportedExerciseNotes(templates, conflict.importedWorkout.blocks);
+      workouts = propagateImportedExerciseNotes(workouts, conflict.importedWorkout.blocks);
+      conflict.retargetDates.forEach((date) => {
+        if (schedule[date] === conflict.existingName) {
+          schedule[date] = newName;
+        }
+      });
+      nextReport.imported.forEach((item) => {
+        if (item.sourceTemplateConflictId === conflict.id) {
+          item.name = newName;
+          item.dates.forEach((date) => {
+            if (schedule[date] === conflict.existingName) {
+              schedule[date] = newName;
+            }
+          });
+        }
+      });
+      nextReport.scheduleConflicts = nextReport.scheduleConflicts.map((item) =>
+        item.sourceTemplateConflictId === conflict.id
+          ? { ...item, importedTitle: newName }
+          : item
+      );
+      nextReport.imported.push({
+        name: newName,
+        dates: conflict.mergedDates,
+        resolution: 'Imported with new name',
+      });
+    } else {
+      return { error: 'Unknown template conflict resolution' };
+    }
+
+    nextReport.templateConflicts = nextReport.templateConflicts.filter(
+      ({ id }) => id !== conflict.id
+    );
+    return { templates, workouts, schedule, report: nextReport };
+  }
+
+  if (resolution.kind === 'schedule') {
+    const conflict = nextReport.scheduleConflicts.find(({ id }) => id === resolution.id);
+    if (!conflict) return { error: 'Schedule import conflict not found' };
+
+    const schedule = { ...snap.schedule };
+    if (resolution.action === 'replace') {
+      schedule[conflict.date] = conflict.importedTitle;
+      nextReport.imported.push({
+        name: conflict.importedTitle,
+        dates: [conflict.date],
+        resolution: 'Replaced scheduled workout',
+        sourceTemplateConflictId: conflict.sourceTemplateConflictId,
+      });
+    } else if (resolution.action === 'keep') {
+      nextReport.alreadyPresent.push({
+        name: conflict.existingTitle,
+        dates: [conflict.date],
+        resolution: 'Kept scheduled workout',
+      });
+    } else {
+      return { error: 'Unknown schedule conflict resolution' };
+    }
+    nextReport.scheduleConflicts = nextReport.scheduleConflicts.filter(
+      ({ id }) => id !== conflict.id
+    );
+    return { schedule, report: nextReport };
+  }
+
+  return { error: 'Unknown import conflict type' };
 }

--- a/src/orchestrator.test.js
+++ b/src/orchestrator.test.js
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { applyTemplateChange, applyScheduleChange, applyNoteChange, applyImport } from './orchestrator';
+import {
+  applyTemplateChange,
+  applyScheduleChange,
+  applyNoteChange,
+  applyImport,
+  applyMergeImport,
+  resolveImportConflict,
+} from './orchestrator';
 
 // ─── applyTemplateChange: delete ────────────────────────
 
@@ -575,5 +582,428 @@ describe('applyImport', () => {
     const result = applyImport(snap, workoutMap, {});
     const tpl = Object.values(result.templates).find((t) => t.name === 'Upper A');
     expect(tpl.blocks[0].exercises[0].workoutNotes).toBe('8 reps each side');
+  });
+});
+
+// ─── applyMergeImport ───────────────────────────────────
+
+describe('applyMergeImport', () => {
+    it('adds new imported training data without removing existing data', () => {
+      const snap = {
+        templates: {
+          existing: {
+            id: 'existing',
+            name: 'Existing',
+            blocks: [{ exercises: [{ title: 'Bench', sets: [{ reps: 5, weight: 100 }] }] }],
+          },
+        },
+        workouts: {
+          Existing: {
+            title: 'Existing',
+            blocks: [{ exercises: [{ title: 'Bench', sets: [{ reps: 5, weight: 100 }] }] }],
+          },
+        },
+        schedule: { '2026-08-01': 'Existing' },
+        logs: {},
+      };
+      const workoutMap = {
+        New: {
+          title: 'New',
+          blocks: [{ exercises: [{ title: 'Squat', sets: [{ reps: 3, weight: 225 }] }] }],
+          notes: '',
+        },
+      };
+
+      const result = applyMergeImport(
+        snap,
+        workoutMap,
+        { '2026-08-02': 'New' },
+        { makeId: () => 'new-template' }
+      );
+
+      expect(Object.keys(result.templates)).toEqual(['existing', 'new-template']);
+      expect(Object.keys(result.workouts)).toEqual(['Existing', 'New']);
+      expect(result.schedule).toEqual({
+        '2026-08-01': 'Existing',
+        '2026-08-02': 'New',
+      });
+      expect(result.report.imported).toEqual([
+        { name: 'New', dates: ['2026-08-02'] },
+      ]);
+    });
+
+    it('normalizes names and separates identical templates from definition conflicts', () => {
+      const existingDefinition = {
+        id: 'upper',
+        name: 'Upper Body',
+        notes: 'Control',
+        blocks: [{
+          value: 'A',
+          exercises: [{
+            title: 'Bench',
+            notes: 'Tuck elbows',
+            workoutNotes: 'Local cue',
+            sets: [{ reps: 5, weight: 185, unit: 'lb' }],
+          }],
+        }],
+      };
+      const snap = {
+        templates: { upper: existingDefinition },
+        workouts: { 'Upper Body': { ...existingDefinition, title: 'Upper Body' } },
+        schedule: {},
+        logs: {},
+      };
+      const identical = {
+        title: '  upper   body ',
+        notes: 'Control',
+        blocks: [{
+          value: 'A',
+          exercises: [{
+            title: 'Bench',
+            notes: 'Tuck elbows',
+            sets: [{ reps: 5, weight: 185, unit: 'lb' }],
+          }],
+        }],
+      };
+      const changed = {
+        ...identical,
+        blocks: [{
+          ...identical.blocks[0],
+          exercises: [{
+            ...identical.blocks[0].exercises[0],
+            sets: [{ reps: 8, weight: 165, unit: 'lb' }],
+          }],
+        }],
+      };
+
+      const alreadyPresent = applyMergeImport(snap, { duplicate: identical }, {});
+      expect(alreadyPresent.report.alreadyPresent).toEqual([{ name: 'Upper Body', dates: [] }]);
+      expect(alreadyPresent.report.templateConflicts).toEqual([]);
+
+      const conflicted = applyMergeImport(snap, { changed }, { '2026-08-03': changed.title });
+      expect(conflicted.report.templateConflicts[0]).toMatchObject({
+        id: 'template:Upper Body',
+        existingName: 'Upper Body',
+        importedName: 'upper body',
+        importedDates: ['2026-08-03'],
+        suggestedName: 'upper body (Imported)',
+      });
+      expect(conflicted.schedule['2026-08-03']).toBe('Upper Body');
+    });
+
+    it('treats different exercise titles as different workout definitions', () => {
+      const snap = {
+        templates: {
+          strength: {
+            id: 'strength',
+            name: 'Strength',
+            blocks: [{ exercises: [{ title: 'Bench', sets: [{ reps: 5 }] }] }],
+          },
+        },
+        workouts: {},
+        schedule: {},
+        logs: {},
+      };
+      const result = applyMergeImport(snap, {
+        strength: {
+          title: 'Strength',
+          blocks: [{ exercises: [{ title: 'Squat', sets: [{ reps: 5 }] }] }],
+        },
+      }, {});
+
+      expect(result.report.alreadyPresent).toEqual([]);
+      expect(result.report.templateConflicts).toHaveLength(1);
+    });
+
+    it('renames a conflicted import, preserves existing dates, and retargets only newly merged dates', () => {
+      const snap = {
+        templates: {
+          upper: {
+            id: 'upper',
+            name: 'Upper',
+            blocks: [{ exercises: [{ title: 'Bench', sets: [{ reps: 5 }] }] }],
+          },
+        },
+        workouts: {
+          Upper: {
+            title: 'Upper',
+            blocks: [{ exercises: [{ title: 'Bench', sets: [{ reps: 5 }] }] }],
+          },
+        },
+        schedule: { '2026-08-04': 'Upper' },
+        logs: {},
+      };
+      const importedWorkout = {
+        title: 'upper',
+        blocks: [{ exercises: [{ title: 'Bench', sets: [{ reps: 8 }] }] }],
+      };
+      const merged = applyMergeImport(
+        snap,
+        { upper: importedWorkout },
+        { '2026-08-04': 'upper', '2026-08-05': 'upper' }
+      );
+
+      const result = resolveImportConflict(
+        {
+          ...snap,
+          templates: merged.templates,
+          workouts: merged.workouts,
+          schedule: merged.schedule,
+        },
+        merged.report,
+        {
+          kind: 'template',
+          id: 'template:Upper',
+          action: 'rename',
+          newName: 'Upper - Coach',
+          makeId: () => 'upper-coach',
+        }
+      );
+
+      expect(result.templates['upper-coach'].name).toBe('Upper - Coach');
+      expect(result.workouts['Upper - Coach'].blocks[0].exercises[0].sets[0].reps).toBe(8);
+      expect(result.schedule['2026-08-04']).toBe('Upper');
+      expect(result.schedule['2026-08-05']).toBe('Upper - Coach');
+      expect(result.report.templateConflicts).toEqual([]);
+    });
+
+    it('protects schedule collisions and completed history until explicitly replaced', () => {
+      const snap = {
+        templates: {},
+        workouts: {},
+        schedule: { '2026-08-06': 'Lower' },
+        logs: {
+          '2026-08-07::Completed Workout': { completed: true },
+        },
+      };
+      const importedWorkout = {
+        title: 'Conditioning',
+        blocks: [{ exercises: [{ title: 'Run', sets: [{ reps: 1 }] }] }],
+      };
+      const merged = applyMergeImport(
+        snap,
+        { conditioning: importedWorkout },
+        {
+          '2026-08-06': 'Conditioning',
+          '2026-08-07': 'Conditioning',
+          '2026-08-08': 'Conditioning',
+        },
+        { makeId: () => 'conditioning' }
+      );
+
+      expect(merged.schedule).toEqual({
+        '2026-08-06': 'Lower',
+        '2026-08-08': 'Conditioning',
+      });
+      expect(merged.report.scheduleConflicts).toEqual([
+        expect.objectContaining({
+          id: 'schedule:2026-08-06',
+          existingTitle: 'Lower',
+          importedTitle: 'Conditioning',
+          completed: false,
+        }),
+        expect.objectContaining({
+          id: 'schedule:2026-08-07',
+          existingTitle: 'Completed Workout',
+          importedTitle: 'Conditioning',
+          completed: true,
+        }),
+      ]);
+
+      const resolved = resolveImportConflict(
+        { ...snap, ...merged },
+        merged.report,
+        { kind: 'schedule', id: 'schedule:2026-08-06', action: 'replace' }
+      );
+      expect(resolved.schedule['2026-08-06']).toBe('Conditioning');
+      expect(resolved.report.scheduleConflicts).toHaveLength(1);
+    });
+
+    it('reviews a completed date even when its logged workout name matches the import', () => {
+      const snap = {
+        templates: {},
+        workouts: {},
+        schedule: {},
+        logs: {
+          '2026-08-09::Conditioning': { completed: true },
+        },
+      };
+      const result = applyMergeImport(
+        snap,
+        {
+          conditioning: {
+            title: 'Conditioning',
+            blocks: [{ exercises: [{ title: 'Run', sets: [{ reps: 1 }] }] }],
+          },
+        },
+        { '2026-08-09': 'Conditioning' },
+        { makeId: () => 'conditioning' }
+      );
+
+      expect(result.schedule['2026-08-09']).toBeUndefined();
+      expect(result.report.imported[0].dates).toEqual([]);
+      expect(result.report.scheduleConflicts[0]).toMatchObject({
+        date: '2026-08-09',
+        completed: true,
+      });
+    });
+
+    it('replaces a conflicting definition while preserving local workout-specific notes', () => {
+      const snap = {
+        templates: {
+          upper: {
+            id: 'upper',
+            name: 'Upper',
+            notes: 'Old',
+            blocks: [{
+              exercises: [{
+                title: 'Bench',
+                workoutNotes: 'Use the blue rack',
+                sets: [{ reps: 5 }],
+              }],
+            }],
+          },
+        },
+        workouts: {},
+        schedule: {},
+        logs: {},
+      };
+      const importedWorkout = {
+        title: 'Upper',
+        notes: 'New',
+        blocks: [{
+          exercises: [{
+            title: 'Bench',
+            notes: 'Trainer cue',
+            sets: [{ reps: 8 }],
+          }],
+        }],
+      };
+      const merged = applyMergeImport(snap, { upper: importedWorkout }, {});
+      const resolved = resolveImportConflict(
+        { ...snap, ...merged },
+        merged.report,
+        { kind: 'template', id: 'template:Upper', action: 'replace' }
+      );
+
+      expect(resolved.templates.upper).toMatchObject({
+        notes: 'New',
+        blocks: [{
+          exercises: [{
+            title: 'Bench',
+            notes: 'Trainer cue',
+            workoutNotes: 'Use the blue rack',
+            sets: [{ reps: 8 }],
+          }],
+        }],
+      });
+      expect(resolved.workouts.Upper.blocks).toEqual(resolved.templates.upper.blocks);
+  });
+
+  it('shares imported coaching notes with matching exercises in existing templates', () => {
+      const snap = {
+        templates: {
+          lower: {
+            id: 'lower',
+            name: 'Lower',
+            blocks: [{ exercises: [{ title: 'Squat', notes: 'Old cue', sets: [] }] }],
+          },
+        },
+        workouts: {
+          Lower: {
+            title: 'Lower',
+            blocks: [{ exercises: [{ title: 'Squat', notes: 'Old cue', sets: [] }] }],
+          },
+        },
+        schedule: {},
+        logs: {},
+      };
+      const result = applyMergeImport(snap, {
+        accessory: {
+          title: 'Accessory',
+          blocks: [{
+            exercises: [{ title: 'Squat', notes: 'Brace before descending', sets: [] }],
+          }],
+        },
+      }, {}, { makeId: () => 'accessory' });
+
+      expect(result.templates.lower.blocks[0].exercises[0].notes).toBe('Brace before descending');
+      expect(result.workouts.Lower.blocks[0].exercises[0].notes).toBe('Brace before descending');
+  });
+
+  it('inherits an existing global coaching note when an import leaves it blank', () => {
+      const snap = {
+        templates: {
+          lower: {
+            id: 'lower',
+            name: 'Lower',
+            blocks: [{ exercises: [{ title: 'Squat', notes: 'Brace hard', sets: [] }] }],
+          },
+        },
+        workouts: {},
+        schedule: {},
+        logs: {},
+      };
+      const result = applyMergeImport(snap, {
+        accessory: {
+          title: 'Accessory',
+          blocks: [{ exercises: [{ title: 'Squat', notes: '', sets: [] }] }],
+        },
+      }, {}, { makeId: () => 'accessory' });
+
+      expect(result.templates.accessory.blocks[0].exercises[0].notes).toBe('Brace hard');
+      expect(result.workouts.Accessory.blocks[0].exercises[0].notes).toBe('Brace hard');
+  });
+
+  it('retargets an already-resolved imported schedule conflict when its template is renamed later', () => {
+      const snap = {
+        templates: {
+          upper: {
+            id: 'upper',
+            name: 'Upper',
+            blocks: [{ exercises: [{ title: 'Bench', sets: [{ reps: 5 }] }] }],
+          },
+        },
+        workouts: {
+          Upper: {
+            title: 'Upper',
+            blocks: [{ exercises: [{ title: 'Bench', sets: [{ reps: 5 }] }] }],
+          },
+        },
+        schedule: { '2026-08-11': 'Lower' },
+        logs: {},
+      };
+      const merged = applyMergeImport(
+        snap,
+        {
+          upper: {
+            title: 'Upper',
+            blocks: [{ exercises: [{ title: 'Bench', sets: [{ reps: 8 }] }] }],
+          },
+        },
+        { '2026-08-11': 'Upper' }
+      );
+      const scheduleResolved = resolveImportConflict(
+        { ...snap, ...merged },
+        merged.report,
+        { kind: 'schedule', id: 'schedule:2026-08-11', action: 'replace' }
+      );
+      const renamed = resolveImportConflict(
+        {
+          ...snap,
+          ...merged,
+          schedule: scheduleResolved.schedule,
+        },
+        scheduleResolved.report,
+        {
+          kind: 'template',
+          id: 'template:Upper',
+          action: 'rename',
+          newName: 'Upper (Imported)',
+          makeId: () => 'upper-imported',
+        }
+      );
+
+      expect(renamed.schedule['2026-08-11']).toBe('Upper (Imported)');
   });
 });

--- a/src/styles/import-view.css
+++ b/src/styles/import-view.css
@@ -210,6 +210,381 @@
   width: 100%;
 }
 
+.import-view__actions--stacked {
+  grid-template-columns: 1fr 1fr;
+}
+
+.import-view__actions--stacked .btn-primary {
+  grid-column: 1 / -1;
+}
+
+.import-view__replace {
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+
+.import-view .btn-ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--text-secondary);
+}
+
+.import-view .btn-ghost:hover:not(:disabled) {
+  background: var(--surface-high);
+  color: var(--text);
+}
+
+.import-view__safe-callout {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-sm);
+  margin-top: var(--space-lg);
+  padding: var(--space-md);
+  border: 1px solid color-mix(in oklch, var(--success) 28%, transparent);
+  border-radius: var(--radius-lg);
+  background: var(--success-subtle);
+  color: var(--success);
+}
+
+.import-view__safe-callout svg {
+  flex-shrink: 0;
+}
+
+.import-view__safe-callout div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.import-view__safe-callout strong {
+  color: var(--text);
+  font-size: var(--text-sm);
+}
+
+.import-view__safe-callout span {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: 1.4;
+}
+
+.import-report {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+  padding-bottom: var(--space-2xl);
+}
+
+.import-report .import-view__header {
+  margin-bottom: 0;
+}
+
+.import-report__summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-sm);
+}
+
+.import-report__summary > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-md) var(--space-sm);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  text-align: center;
+}
+
+.import-report__summary span {
+  color: var(--accent-text);
+  font-family: var(--font-mono);
+  font-size: var(--num-md);
+  font-weight: 800;
+}
+
+.import-report__summary small {
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+}
+
+.import-report__section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.import-report__section h2 {
+  margin: 0;
+  font-size: var(--text-lg);
+}
+
+.import-report__section h2 > span {
+  display: inline-grid;
+  min-width: 22px;
+  height: 22px;
+  margin-left: var(--space-xs);
+  place-items: center;
+  border-radius: var(--radius-full);
+  background: var(--surface-high);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.import-report__section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.import-report__section-head > div {
+  display: flex;
+  gap: var(--space-xs);
+}
+
+.import-report__section-head .btn {
+  min-height: 34px;
+  padding: var(--space-xs) var(--space-sm);
+  font-size: var(--text-xs);
+}
+
+.import-report__list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.import-report__list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface);
+  font-size: var(--text-sm);
+}
+
+.import-report__list li span,
+.import-report__empty {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+
+.import-report__empty {
+  margin: 0;
+  padding: var(--space-md);
+  border: 1px dashed var(--border-subtle);
+  border-radius: var(--radius-md);
+  text-align: center;
+}
+
+.import-conflict {
+  padding: var(--space-md);
+  border: 1px solid color-mix(in oklch, var(--warning) 34%, var(--border-subtle));
+  border-radius: var(--radius-xl);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
+}
+
+.import-conflict__head,
+.import-conflict--schedule,
+.import-conflict__actions,
+.import-conflict__rename > div {
+  display: flex;
+  align-items: center;
+}
+
+.import-conflict__head,
+.import-conflict--schedule {
+  justify-content: space-between;
+  gap: var(--space-md);
+}
+
+.import-conflict h3,
+.import-conflict h4 {
+  margin: 0;
+}
+
+.import-conflict h3 {
+  font-size: var(--text-md);
+}
+
+.import-conflict p {
+  margin: var(--space-xs) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: 1.45;
+}
+
+.import-conflict__badge {
+  flex-shrink: 0;
+  padding: 4px 8px;
+  border-radius: var(--radius-full);
+  background: color-mix(in oklch, var(--warning) 16%, transparent);
+  color: var(--warning);
+  font-size: 10px;
+  font-weight: 800;
+  text-transform: uppercase;
+}
+
+.import-conflict__details {
+  margin-top: var(--space-md);
+  border-block: 1px solid var(--border-subtle);
+}
+
+.import-conflict__details summary {
+  padding-block: var(--space-sm);
+  color: var(--accent-text);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  font-weight: 750;
+}
+
+.import-conflict__compare {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-sm);
+  padding-bottom: var(--space-md);
+}
+
+.import-conflict__compare > div {
+  min-width: 0;
+  padding: var(--space-sm);
+  border-radius: var(--radius-md);
+  background: var(--surface-high);
+}
+
+.import-conflict__compare h4 {
+  margin-bottom: var(--space-xs);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+
+.import-conflict__workout-note,
+.import-conflict__block > p {
+  margin: 0 0 var(--space-xs);
+  color: var(--text-secondary);
+  font-size: 10px;
+  line-height: 1.35;
+}
+
+.import-conflict__block + .import-conflict__block {
+  margin-top: var(--space-sm);
+}
+
+.import-conflict__block h5 {
+  margin: 0 0 var(--space-xs);
+  color: var(--accent-text);
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.import-conflict__compare ul {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.import-conflict__compare li {
+  display: flex;
+  min-width: 0;
+  justify-content: space-between;
+  gap: var(--space-xs);
+  font-size: var(--text-xs);
+}
+
+.import-conflict__compare li > div {
+  min-width: 0;
+}
+
+.import-conflict__compare li span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.import-conflict__compare li > div small {
+  display: block;
+  margin-top: 2px;
+  color: var(--text-secondary);
+  line-height: 1.35;
+}
+
+.import-conflict__compare li > small {
+  max-width: 56%;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  line-height: 1.35;
+  text-align: right;
+}
+
+.import-conflict__actions {
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+.import-conflict__actions .btn {
+  flex: 1;
+}
+
+.import-conflict__rename {
+  margin-top: var(--space-md);
+}
+
+.import-conflict__rename label {
+  display: block;
+  margin-bottom: var(--space-xs);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 700;
+}
+
+.import-conflict__rename > div {
+  gap: var(--space-sm);
+}
+
+.import-conflict__rename input {
+  min-width: 0;
+  flex: 1;
+}
+
+.import-conflict__rename .btn {
+  flex-shrink: 0;
+}
+
+.import-conflict--schedule .import-conflict__actions {
+  min-width: 240px;
+  margin-top: 0;
+}
+
+.import-report__resolved {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border-radius: var(--radius-lg);
+  background: var(--success-subtle);
+  color: var(--success);
+  font-size: var(--text-sm);
+}
+
 .import-view__errors {
   margin: var(--space-lg) 0 0;
   border-color: color-mix(in oklch, var(--danger) 34%, transparent);
@@ -268,5 +643,36 @@
   .import-view__stats,
   .import-view__actions {
     grid-template-columns: 1fr;
+  }
+
+  .import-view__actions--stacked .btn-primary {
+    grid-column: auto;
+  }
+
+  .import-report__summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .import-report__section-head,
+  .import-conflict--schedule,
+  .import-conflict__rename > div {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .import-report__section-head > div {
+    width: 100%;
+  }
+
+  .import-report__section-head .btn {
+    flex: 1;
+  }
+
+  .import-conflict__compare {
+    grid-template-columns: 1fr;
+  }
+
+  .import-conflict--schedule .import-conflict__actions {
+    min-width: 0;
   }
 }

--- a/src/views/ImportView.jsx
+++ b/src/views/ImportView.jsx
@@ -1,14 +1,369 @@
-import { useRef, useState } from 'react';
-import { AlertTriangle, CheckCircle2, ClipboardPaste, FileUp, RefreshCw } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ClipboardPaste,
+  FileUp,
+  GitMerge,
+  RefreshCw,
+  ShieldCheck,
+} from 'lucide-react';
 import { parseCSV, getParseStats } from '../csv/parser';
+import Modal from '../components/Modal';
 
-export default function ImportView({ onImport }) {
+function exerciseSummary(definition) {
+  const exercises = (definition.blocks || []).flatMap((block) => block.exercises || []);
+  return exercises.map((exercise) => ({
+    title: exercise.title,
+    notes: exercise.notes || '',
+    sets: exercise.sets || [],
+  }));
+}
+
+function setTarget(set) {
+  const reps = set.reps ?? set.rawReps ?? '—';
+  const weight = set.weight ?? set.rawWeight;
+  const unit = set.unit || '';
+  if (String(weight).toLowerCase() === 'bw' || unit === 'bw') {
+    return `${reps} reps @ bodyweight`;
+  }
+  return weight === null || weight === undefined || weight === ''
+    ? `${reps} reps`
+    : `${reps} reps @ ${weight} ${unit}`.trim();
+}
+
+function definitionChanges(conflict) {
+  const existing = new Map(
+    exerciseSummary(conflict.existingTemplate).map((exercise) => [exercise.title, exercise])
+  );
+  const imported = new Map(
+    exerciseSummary(conflict.importedWorkout).map((exercise) => [exercise.title, exercise])
+  );
+  const added = [...imported.keys()].filter((title) => !existing.has(title));
+  const removed = [...existing.keys()].filter((title) => !imported.has(title));
+  const changed = [...imported.keys()].filter((title) =>
+    existing.has(title) &&
+    JSON.stringify(existing.get(title)) !== JSON.stringify(imported.get(title))
+  );
+  return { added, removed, changed };
+}
+
+function ResultList({ title, items, emptyText }) {
+  return (
+    <section className="import-report__section">
+      <h2>{title} <span>{items.length}</span></h2>
+      {items.length ? (
+        <ul className="import-report__list">
+          {items.map((item, index) => (
+            <li key={`${item.name}-${index}`}>
+              <strong>{item.name}</strong>
+              <span>
+                {item.resolution || `${item.dates.length} scheduled date${item.dates.length === 1 ? '' : 's'}`}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : <p className="import-report__empty">{emptyText}</p>}
+    </section>
+  );
+}
+
+function DefinitionPanel({ label, definition }) {
+  return (
+    <div>
+      <h4>{label}</h4>
+      {definition.notes && <p className="import-conflict__workout-note">{definition.notes}</p>}
+      {(definition.blocks || []).map((block, blockIndex) => (
+        <section className="import-conflict__block" key={`${block.value || 'part'}-${blockIndex}`}>
+          {(block.value || block.units) && (
+            <h5>{[block.value, block.units].filter(Boolean).join(' · ')}</h5>
+          )}
+          {block.instructions && <p>{block.instructions}</p>}
+          {block.notes && <p>{block.notes}</p>}
+          <ul>
+            {(block.exercises || []).map((exercise) => (
+              <li key={exercise.title}>
+                <div>
+                  <span>{exercise.title}</span>
+                  {exercise.notes && <small>{exercise.notes}</small>}
+                  {exercise.workoutNotes && <small>{exercise.workoutNotes}</small>}
+                </div>
+                <small>
+                  {(exercise.sets || []).length
+                    ? exercise.sets.map(setTarget).join(' · ')
+                    : 'No prescribed sets'}
+                  {exercise.restDuration ? ` · Rest ${exercise.restDuration}s` : ''}
+                  {exercise.barWeight ? ` · Bar ${exercise.barWeight}` : ''}
+                </small>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function TemplateConflict({
+  conflict,
+  renameValue,
+  onRenameChange,
+  onResolve,
+}) {
+  const changes = definitionChanges(conflict);
+  const changeLabels = [
+    changes.added.length && `${changes.added.length} added`,
+    changes.removed.length && `${changes.removed.length} removed`,
+    changes.changed.length && `${changes.changed.length} prescription changed`,
+  ].filter(Boolean);
+
+  return (
+    <article className="import-conflict">
+      <div className="import-conflict__head">
+        <div>
+          <h3>{conflict.existingName}</h3>
+          <p>{changeLabels.join(' · ') || 'Notes or prescribed sets differ'}</p>
+        </div>
+        <span className="import-conflict__badge">Needs choice</span>
+      </div>
+
+      <details className="import-conflict__details">
+        <summary>Compare workout definitions</summary>
+        <div className="import-conflict__compare">
+          {[
+            ['Current', conflict.existingTemplate],
+            ['Imported', conflict.importedWorkout],
+          ].map(([label, definition]) => (
+            <DefinitionPanel key={label} label={label} definition={definition} />
+          ))}
+        </div>
+      </details>
+
+      <div className="import-conflict__actions">
+        <button className="btn btn-secondary" onClick={() => onResolve('keep')}>
+          Keep current
+        </button>
+        <button className="btn btn-secondary" onClick={() => onResolve('replace')}>
+          Use imported
+        </button>
+      </div>
+      <div className="import-conflict__rename">
+        <label htmlFor={`rename-${conflict.id}`}>Import a separate copy</label>
+        <div>
+          <input
+            id={`rename-${conflict.id}`}
+            value={renameValue}
+            onChange={(event) => onRenameChange(event.target.value)}
+          />
+          <button className="btn btn-primary" onClick={() => onResolve('rename')}>
+            Import with new name
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function ImportReport({ report, onResolveConflict, onUpdateReport, onDone }) {
+  const [renameValues, setRenameValues] = useState(() =>
+    Object.fromEntries(report.templateConflicts.map((conflict) => [
+      conflict.id,
+      conflict.suggestedName,
+    ]))
+  );
+  const conflictCount = report.templateConflicts.length + report.scheduleConflicts.length;
+
+  const resolve = (currentReport, resolution) => {
+    const nextReport = onResolveConflict(currentReport, resolution);
+    return nextReport || currentReport;
+  };
+
+  const resolveOne = (resolution) => {
+    const nextReport = resolve(report, resolution);
+    if (nextReport !== report) {
+      onUpdateReport(nextReport);
+    }
+  };
+
+  const resolveAll = (kind, action) => {
+    let nextReport = report;
+    const conflicts = kind === 'template'
+      ? [...nextReport.templateConflicts]
+      : [...nextReport.scheduleConflicts];
+    conflicts.forEach((conflict) => {
+      nextReport = resolve(nextReport, { kind, id: conflict.id, action });
+    });
+    onUpdateReport(nextReport);
+  };
+
+  const finish = () => {
+    let nextReport = report;
+    [...nextReport.templateConflicts].forEach((conflict) => {
+      nextReport = resolve(nextReport, {
+        kind: 'template',
+        id: conflict.id,
+        action: 'keep',
+      });
+    });
+    [...nextReport.scheduleConflicts].forEach((conflict) => {
+      nextReport = resolve(nextReport, {
+        kind: 'schedule',
+        id: conflict.id,
+        action: 'keep',
+      });
+    });
+    onDone();
+  };
+
+  return (
+    <div className="import-report">
+      <div className="import-view__header">
+        <span className="import-view__icon" aria-hidden="true"><GitMerge size={28} /></span>
+        <h1>Import report</h1>
+        <p>Safe items are already added. Review anything that matched existing data.</p>
+      </div>
+
+      <div className="import-report__summary" aria-label="Import summary">
+        {[
+          ['Imported', report.imported.length],
+          ['Already present', report.alreadyPresent.length],
+          ['Template conflicts', report.templateConflicts.length],
+          ['Schedule conflicts', report.scheduleConflicts.length],
+        ].map(([label, count]) => (
+          <div key={label}>
+            <span>{count}</span>
+            <small>{label}</small>
+          </div>
+        ))}
+      </div>
+
+      <ResultList title="Imported" items={report.imported} emptyText="No new templates were added." />
+      <ResultList
+        title="Already present"
+        items={report.alreadyPresent}
+        emptyText="No exact matches were found."
+      />
+
+      <section className="import-report__section">
+        <div className="import-report__section-head">
+          <h2>Template conflicts <span>{report.templateConflicts.length}</span></h2>
+          {report.templateConflicts.length > 1 && (
+            <div>
+              <button className="btn btn-ghost" onClick={() => resolveAll('template', 'keep')}>
+                Keep all current
+              </button>
+              <button className="btn btn-ghost" onClick={() => resolveAll('template', 'replace')}>
+                Use all imported
+              </button>
+            </div>
+          )}
+        </div>
+        {report.templateConflicts.map((conflict) => (
+          <TemplateConflict
+            key={conflict.id}
+            conflict={conflict}
+            renameValue={renameValues[conflict.id] || conflict.suggestedName}
+            onRenameChange={(value) => setRenameValues((current) => ({
+              ...current,
+              [conflict.id]: value,
+            }))}
+            onResolve={(action) => resolveOne({
+              kind: 'template',
+              id: conflict.id,
+              action,
+              newName: renameValues[conflict.id] || conflict.suggestedName,
+            })}
+          />
+        ))}
+        {!report.templateConflicts.length && (
+          <p className="import-report__empty">No unresolved template conflicts.</p>
+        )}
+      </section>
+
+      <section className="import-report__section">
+        <div className="import-report__section-head">
+          <h2>Schedule conflicts <span>{report.scheduleConflicts.length}</span></h2>
+          {report.scheduleConflicts.length > 1 && (
+            <div>
+              <button className="btn btn-ghost" onClick={() => resolveAll('schedule', 'keep')}>
+                Keep all scheduled
+              </button>
+              <button className="btn btn-ghost" onClick={() => resolveAll('schedule', 'replace')}>
+                Use all imported
+              </button>
+            </div>
+          )}
+        </div>
+        {report.scheduleConflicts.map((conflict) => (
+          <article className="import-conflict import-conflict--schedule" key={conflict.id}>
+            <div>
+              <h3>{conflict.date}</h3>
+              <p>
+                Keep <strong>{conflict.existingTitle}</strong> or schedule{' '}
+                <strong>{conflict.importedTitle}</strong>
+                {conflict.completed ? ' (a completed workout exists on this date)' : ''}.
+              </p>
+            </div>
+            <div className="import-conflict__actions">
+              <button className="btn btn-secondary" onClick={() => resolveOne({
+                kind: 'schedule',
+                id: conflict.id,
+                action: 'keep',
+              })}>
+                Keep scheduled
+              </button>
+              <button className="btn btn-primary" onClick={() => resolveOne({
+                kind: 'schedule',
+                id: conflict.id,
+                action: 'replace',
+              })}>
+                Use imported
+              </button>
+            </div>
+          </article>
+        ))}
+        {!report.scheduleConflicts.length && (
+          <p className="import-report__empty">No unresolved schedule conflicts.</p>
+        )}
+      </section>
+
+      {!conflictCount && (
+        <div className="import-report__resolved">
+          <CheckCircle2 size={20} />
+          <strong>All conflicts resolved</strong>
+        </div>
+      )}
+      <button className="btn btn-primary btn--large w-full" onClick={finish}>
+        {conflictCount ? 'Keep unresolved items and finish' : 'Done'}
+      </button>
+    </div>
+  );
+}
+
+export default function ImportView({
+  onMergeImport,
+  onResolveConflict,
+  onReplaceImport,
+  onDone,
+  existingCounts = { workouts: 0, scheduledDates: 0 },
+}) {
   const fileInputRef = useRef(null);
   const [parseStats, setParseStats] = useState(null);
   const [parseErrors, setParseErrors] = useState([]);
   const [isReady, setIsReady] = useState(false);
   const [csvText, setCsvText] = useState('');
   const [isDragging, setIsDragging] = useState(false);
+  const [report, setReport] = useState(null);
+  const [showReplaceConfirm, setShowReplaceConfirm] = useState(false);
+  const viewRef = useRef(null);
+  const hasShownReportRef = useRef(false);
+
+  useEffect(() => {
+    if (report && !hasShownReportRef.current) {
+      viewRef.current?.scrollTo?.({ top: 0 });
+      hasShownReportRef.current = true;
+    }
+  }, [report]);
 
   const parseCsvText = (text) => {
     if (!text || !text.trim()) {
@@ -20,19 +375,16 @@ export default function ImportView({ onImport }) {
 
     try {
       const { workoutMap, scheduleMap, parseErrors: errors } = parseCSV(text);
-
       if (errors.length > 0) {
         setParseErrors(errors);
         setParseStats(null);
         setIsReady(false);
         return;
       }
-
-      const stats = getParseStats(workoutMap, scheduleMap);
       setParseStats({
         workoutMap,
         scheduleMap,
-        stats,
+        stats: getParseStats(workoutMap, scheduleMap),
       });
       setParseErrors([]);
       setIsReady(true);
@@ -54,72 +406,68 @@ export default function ImportView({ onImport }) {
     reader.readAsText(file);
   };
 
-  const handleFileSelect = (e) => {
-    handleFile(e.target.files?.[0]);
+  const handleMerge = () => {
+    if (!parseStats || !isReady) return;
+    setReport(onMergeImport(parseStats.workoutMap, parseStats.scheduleMap));
   };
 
-  const handleDrop = (e) => {
-    e.preventDefault();
-    setIsDragging(false);
-    handleFile(e.dataTransfer.files?.[0]);
-  };
-
-  const handleImport = () => {
-    if (parseStats && isReady) {
-      onImport(parseStats.workoutMap, parseStats.scheduleMap);
-    }
-  };
+  if (report) {
+    return (
+      <div ref={viewRef} className="view view--full-height import-view">
+        <div className="import-view__content">
+          <ImportReport
+            report={report}
+            onResolveConflict={onResolveConflict}
+            onUpdateReport={setReport}
+            onDone={onDone}
+          />
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="view view--full-height import-view">
+    <div ref={viewRef} className="view view--full-height import-view">
       <div className="import-view__content">
         <div className="import-view__header">
-          <span className="import-view__icon" aria-hidden="true">
-            <FileUp size={28} />
-          </span>
+          <span className="import-view__icon" aria-hidden="true"><FileUp size={28} /></span>
           <h1>Import TrainHeroic CSV</h1>
-          <p>Drop an export, choose a file, or paste raw CSV to build workouts, schedule, and templates.</p>
+          <p>Add a partial or complete export without losing workouts already in TrainLog.</p>
         </div>
 
         {!parseStats ? (
           <div
             className={`import-view__upload${isDragging ? ' import-view__upload--dragging' : ''}`}
-            onDragOver={(e) => {
-              e.preventDefault();
+            onDragOver={(event) => {
+              event.preventDefault();
               setIsDragging(true);
             }}
             onDragLeave={() => setIsDragging(false)}
-            onDrop={handleDrop}
+            onDrop={(event) => {
+              event.preventDefault();
+              setIsDragging(false);
+              handleFile(event.dataTransfer.files?.[0]);
+            }}
           >
             <input
               ref={fileInputRef}
               type="file"
               accept=".csv"
-              onChange={handleFileSelect}
+              onChange={(event) => handleFile(event.target.files?.[0])}
               className="import-view__file-input"
             />
-            <span className="import-view__drop-icon" aria-hidden="true">
-              <FileUp size={30} />
-            </span>
-            <button
-              className="btn btn-primary btn--large"
-              onClick={() => fileInputRef.current?.click()}
-            >
+            <span className="import-view__drop-icon" aria-hidden="true"><FileUp size={30} /></span>
+            <button className="btn btn-primary btn--large" onClick={() => fileInputRef.current?.click()}>
               Choose CSV File
             </button>
-            <p>
-              Drag a .csv file here, or choose from Files.
-            </p>
+            <p>Drag a .csv file here, or choose from Files.</p>
             <div className="import-view__paste">
-              <label htmlFor="csv-paste">
-                <ClipboardPaste size={15} />
-                Paste CSV
-              </label>
+              <label htmlFor="csv-paste"><ClipboardPaste size={15} />Paste CSV</label>
               <textarea
                 id="csv-paste"
                 value={csvText}
-                onChange={(e) => {
-                  setCsvText(e.target.value);
+                onChange={(event) => {
+                  setCsvText(event.target.value);
                   if (parseErrors.length) setParseErrors([]);
                 }}
                 placeholder="WorkoutTitle,ScheduledDate,ExerciseTitle,ExerciseData..."
@@ -137,38 +485,45 @@ export default function ImportView({ onImport }) {
         ) : (
           <div className="import-view__preview card">
             <div className="import-view__preview-head">
-              <span aria-hidden="true"><CheckCircle2 size={22} /></span>
+              <span aria-hidden="true"><ShieldCheck size={22} /></span>
               <div>
                 <h2>Ready to import</h2>
-                <p>Review the parsed program before replacing local workout data.</p>
+                <p>Merge safely is recommended for partial and complete exports.</p>
               </div>
             </div>
             <div className="import-view__stats">
-              <div className="import-stat">
-                <div className="stat-label">Workouts</div>
-                <div className="stat-value">{parseStats.stats.workoutCount}</div>
-              </div>
-              <div className="import-stat">
-                <div className="stat-label">Exercises</div>
-                <div className="stat-value">{parseStats.stats.exerciseCount}</div>
-              </div>
-              <div className="import-stat">
-                <div className="stat-label">Scheduled Dates</div>
-                <div className="stat-value">{parseStats.stats.scheduledDates}</div>
-              </div>
+              {[
+                ['Workouts', parseStats.stats.workoutCount],
+                ['Exercises', parseStats.stats.exerciseCount],
+                ['Scheduled Dates', parseStats.stats.scheduledDates],
+              ].map(([label, value]) => (
+                <div className="import-stat" key={label}>
+                  <div className="stat-label">{label}</div>
+                  <div className="stat-value">{value}</div>
+                </div>
+              ))}
             </div>
             {parseStats.stats.dateRange && (
               <p className="import-view__date-range">
                 {parseStats.stats.dateRange.min} to {parseStats.stats.dateRange.max}
               </p>
             )}
-            <div className="import-view__actions">
-              <button className="btn btn-secondary" onClick={() => setParseStats(null)}>
-                <RefreshCw size={15} />
-                Change File
+            <div className="import-view__safe-callout">
+              <ShieldCheck size={18} />
+              <div>
+                <strong>Keeps everything already in TrainLog</strong>
+                <span>New workouts and dates are added; matches are sent to a review report.</span>
+              </div>
+            </div>
+            <div className="import-view__actions import-view__actions--stacked">
+              <button className="btn btn-primary btn--large" onClick={handleMerge}>
+                <GitMerge size={17} /> Merge safely
               </button>
-              <button className="btn btn-primary" onClick={handleImport}>
-                Import Data
+              <button className="btn btn-secondary" onClick={() => setParseStats(null)}>
+                <RefreshCw size={15} /> Change File
+              </button>
+              <button className="btn btn-ghost import-view__replace" onClick={() => setShowReplaceConfirm(true)}>
+                Replace all workouts and schedule
               </button>
             </div>
           </div>
@@ -180,14 +535,24 @@ export default function ImportView({ onImport }) {
               <span aria-hidden="true"><AlertTriangle size={18} /></span>
               <h3>CSV needs attention</h3>
             </div>
-            <ul>
-              {parseErrors.map((err, i) => (
-                <li key={i}>{err}</li>
-              ))}
-            </ul>
+            <ul>{parseErrors.map((error) => <li key={error}>{error}</li>)}</ul>
           </div>
         )}
       </div>
+
+      {showReplaceConfirm && (
+        <Modal
+          title="Replace all workout data?"
+          message={`This replaces ${existingCounts.workouts} workouts and ${existingCounts.scheduledDates} scheduled dates. Only continue with a complete export. Completed workout history is preserved.`}
+          confirmText="Replace all"
+          isDestructive
+          onCancel={() => setShowReplaceConfirm(false)}
+          onConfirm={() => {
+            onReplaceImport(parseStats.workoutMap, parseStats.scheduleMap);
+            setShowReplaceConfirm(false);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/views/ImportView.test.jsx
+++ b/src/views/ImportView.test.jsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ImportView from './ImportView';
+
+const csv = `WorkoutTitle,ScheduledDate,ExerciseTitle,ExerciseData
+Upper,2026-08-10,Bench Press,5 rep x 185 pound`;
+
+describe('ImportView', () => {
+  it('defaults to safe merge and exposes template conflict remediation', () => {
+    const report = {
+      imported: [],
+      alreadyPresent: [],
+      templateConflicts: [{
+        id: 'template:Upper',
+        existingName: 'Upper',
+        importedName: 'Upper',
+        importedDates: ['2026-08-10'],
+        suggestedName: 'Upper (Imported)',
+        existingTemplate: {
+          blocks: [{
+            exercises: [{
+              title: 'Bench Press',
+              notes: 'Pause on the chest',
+              sets: [{ reps: 3, weight: 205, unit: 'lb' }],
+            }],
+          }],
+        },
+        importedWorkout: {
+          blocks: [{
+            exercises: [{
+              title: 'Bench Press',
+              notes: 'Keep elbows tucked',
+              sets: [{ reps: 5, weight: 185, unit: 'lb' }],
+            }],
+          }],
+        },
+      }],
+      scheduleConflicts: [],
+    };
+    const onMergeImport = vi.fn(() => report);
+    const onResolveConflict = vi.fn((currentReport) => ({
+      ...currentReport,
+      imported: [{ name: 'Upper (Imported)', dates: ['2026-08-10'] }],
+      templateConflicts: [],
+    }));
+
+    render(
+      <ImportView
+        onMergeImport={onMergeImport}
+        onResolveConflict={onResolveConflict}
+        onReplaceImport={vi.fn()}
+        onDone={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Paste CSV'), { target: { value: csv } });
+    fireEvent.click(screen.getByRole('button', { name: 'Preview pasted CSV' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Merge safely' }));
+
+    expect(onMergeImport).toHaveBeenCalledOnce();
+    expect(screen.getByRole('heading', { name: 'Import report' })).toBeTruthy();
+    expect(screen.getAllByText('Template conflicts')).toHaveLength(2);
+    fireEvent.click(screen.getByText('Compare workout definitions'));
+    expect(screen.getByText(/5 reps @ 185 lb/i)).toBeTruthy();
+    expect(screen.getByText('Keep elbows tucked')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Import with new name' }));
+    expect(onResolveConflict).toHaveBeenCalledWith(
+      report,
+      expect.objectContaining({
+        kind: 'template',
+        id: 'template:Upper',
+        action: 'rename',
+        newName: 'Upper (Imported)',
+      })
+    );
+    expect(screen.getByText('All conflicts resolved')).toBeTruthy();
+  });
+
+  it('guards full replacement with the current data counts', () => {
+    const onReplaceImport = vi.fn();
+    render(
+      <ImportView
+        onMergeImport={vi.fn()}
+        onResolveConflict={vi.fn()}
+        onReplaceImport={onReplaceImport}
+        onDone={vi.fn()}
+        existingCounts={{ workouts: 12, scheduledDates: 24 }}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Paste CSV'), { target: { value: csv } });
+    fireEvent.click(screen.getByRole('button', { name: 'Preview pasted CSV' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Replace all workouts and schedule' }));
+
+    expect(screen.getByText(/replaces 12 workouts and 24 scheduled dates/i)).toBeTruthy();
+    expect(onReplaceImport).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: 'Replace all' }));
+    expect(onReplaceImport).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Why

Partial TrainHeroic exports previously replaced TrainLog's active workout and schedule data, so importing newly added workouts could silently drop existing work. This adds a safe default flow for incremental imports while retaining the full-replacement option for complete exports.

## What changed

- Makes **Merge safely** the primary import action, preserving existing templates, runnable workouts, schedules, and completed logs.
- Normalizes template names and separates new imports, exact matches, template conflicts, and schedule conflicts into an actionable report.
- Supports keeping the current definition, using the imported definition, or importing under an editable unique name, with bulk keep/replace actions.
- Preserves local workout-specific notes, maintains global coaching notes, protects completed dates, and retargets newly imported dates when a conflict is renamed.
- Adds expandable side-by-side workout comparisons and responsive desktop/mobile conflict remediation.
- Keeps **Replace all workouts and schedule** behind a counted destructive confirmation for complete exports.

## Validation

- `npm run test:ci`
- `npm run test:e2e:visual -- e2e/import-smoke.e2e.js`
- Desktop and mobile conflict-report evidence inspected.